### PR TITLE
feat: setup dnd5e baseline

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,9 +7,9 @@ module.exports = {
   parserOptions: {
     sourceType: 'module'
   },
-  plugins: ['@typescript-eslint', 'eslint-plugin-tsdoc'],
+  plugins: ['@typescript-eslint' /*, 'eslint-plugin-tsdoc'*/],
   rules: {
-    'tsdoc/syntax': 'warn',
+    //'tsdoc/syntax': 'warn',
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off'
   }

--- a/dnd5e/dnd5e.d.ts
+++ b/dnd5e/dnd5e.d.ts
@@ -46,6 +46,7 @@ declare namespace DND5e {
     | 'feat'
     | 'backpack';
 
+  export type DistanceUnit = 'none' | 'self' | 'touch' | 'spec' | 'any';
   export type TargetUnitType = 'none' | 'self' | 'touch' | 'special' | 'any' | 'ft' | 'miles';
   export type DamageType =
     | 'acid'
@@ -60,11 +61,11 @@ declare namespace DND5e {
     | 'psychic'
     | 'radiant'
     | 'slashing'
-    | 'thunder'
-    | 'none';
+    | 'thunder';
+  export type DamageResistanceType = DamageType | 'none';
 
   export type AttackType = 'mwak' | 'rwak' | 'rsak' | 'msak';
-  export type ActionType = AttackType | 'save';
+  export type ActionType = AttackType | 'save' | 'heal' | 'abil' | 'util' | 'other';
   export type ActivationType = 'action' | 'bonus' | 'reaction' | 'special';
   export type ToolProficiency =
     | 'herb'
@@ -78,22 +79,8 @@ declare namespace DND5e {
     | 'thief'
     | 'vehicle';
 
-  export type TargetType =
-    | 'ally'
-    | 'cone'
-    | 'creature'
-    | 'cube'
-    | 'cylinder'
-    | 'enemy'
-    | 'line'
-    | 'none'
-    | 'object'
-    | 'radius'
-    | 'self'
-    | 'space'
-    | 'sphere'
-    | 'square'
-    | 'wall';
+  export type AreaTarget = 'cone' | 'cube' | 'cylinder' | 'line' | 'radius' | 'sphere' | 'square' | 'wall';
+  export type TargetType = AreaTarget | 'ally' | 'creature' | 'enemy' | 'none' | 'object' | 'self' | 'space';
 
   export type DurationType =
     | 'days'
@@ -119,7 +106,7 @@ declare namespace DND5e {
     total: number;
   }
 
-  export type Skills =
+  export type SkillType =
     | 'acr'
     | 'ani'
     | 'arc'
@@ -166,20 +153,32 @@ declare namespace DND5e {
 
   export type Senses = 'darkvision' | 'blindsense' | 'tremorsense' | 'truesight' | 'special';
 
-  export type Currencies = 'cp' | 'sp' | 'gp' | 'ep' | 'pp';
+  export type Currency = 'cp' | 'sp' | 'gp' | 'ep' | 'pp';
 
-  export type School = 'abj' | 'con' | 'div' | 'enc' | 'evo' | 'ill' | 'nec' | 'trs';
-  export type Preparation = 'prepared' | 'always';
+  export type SpellSchool = 'abj' | 'con' | 'div' | 'enc' | 'evo' | 'ill' | 'nec' | 'trs';
+  export type Preparation = 'prepared' | 'pact' | 'always' | 'atwill' | 'innate';
 
   export type SpellLevel = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
   export type SpellType = `spell${SpellLevel}` | 'pact';
 
   export type Resources = 'primary' | 'secondary' | 'tertiary';
 
-  export type ConsumeType = string;
+  export type ConsumeType = 'ammo' | 'attribute' | 'material' | 'charges';
+  export type ConsumableType = 'ammo' | 'potion' | 'poison' | 'food' | 'scroll' | 'wand' | 'rod' | 'trinket';
   export type ConsumeTarget = string;
 
-  export type ArmorType = 'light' | 'medium' | 'heavy';
+  export type ArmorType =
+    | 'light'
+    | 'medium'
+    | 'heavy'
+    | 'bonus'
+    | 'natural'
+    | 'shield'
+    | 'clothing'
+    | 'trinket'
+    | 'vehicle';
+
+  export type ArmorProficiencies = 'lgt' | 'med' | 'hvy' | 'shl';
 
   export type Size = 'grg' | 'huge' | 'lg' | 'med' | 'sm' | 'tiny';
   export type Alignment = 'ce' | 'cg' | 'cn' | 'le' | 'lg' | 'ln' | 'ne' | 'ng' | 'tn';
@@ -201,6 +200,108 @@ declare namespace DND5e {
     | 'restrained'
     | 'stunned'
     | 'unconscious';
+
+  export type WeaponProficiency = 'sim' | 'mar';
+
+  export type TimePeriod = 'inst' | 'turn' | 'round' | 'minute' | 'hour' | 'day' | 'month' | 'year' | 'perm' | 'spec';
+
+  export type AbilityActivationType =
+    | 'none'
+    | 'action'
+    | 'bonus'
+    | 'reaction'
+    | 'minute'
+    | 'hour'
+    | 'day'
+    | 'special'
+    | 'legendary'
+    | 'lair'
+    | 'crew';
+
+  export type UsePeriod = 'sr' | 'lr' | 'day' | 'charges';
+  export type Unit = 'ft' | 'mi';
+
+  export type SpellcasterProgression = 'none' | 'full' | 'half' | 'third' | 'pact' | 'artificer';
+  export type SpellScaling = 'none' | 'cantrip' | 'level';
+
+  export type WeaponProperty =
+    | 'ada'
+    | 'amm'
+    | 'fin'
+    | 'fir'
+    | 'foc'
+    | 'hvy'
+    | 'lgt'
+    | 'lod'
+    | 'mgc'
+    | 'rch'
+    | 'rel'
+    | 'ret'
+    | 'sil'
+    | 'spc'
+    | 'thr'
+    | 'two'
+    | 'ver';
+
+  export type SpellComponent = 'V' | 'S' | 'M';
+
+  export type PolymorphSetting =
+    | 'keepPhysical'
+    | 'keepMental'
+    | 'keepSaves'
+    | 'keepSkills'
+    | 'mergeSaves'
+    | 'mergeSkills'
+    | 'keepClass'
+    | 'keepFeats'
+    | 'keepSpells'
+    | 'keepItems'
+    | 'keepBio'
+    | 'keepVision';
+
+  export type Language =
+    | 'common'
+    | 'aarakocra'
+    | 'abyssal'
+    | 'aquan'
+    | 'auran'
+    | 'celestial'
+    | 'deep'
+    | 'draconic'
+    | 'druidic'
+    | 'dwarvish'
+    | 'elvish'
+    | 'giant'
+    | 'gith'
+    | 'gnomish'
+    | 'goblin'
+    | 'gnoll'
+    | 'halfling'
+    | 'ignan'
+    | 'infernal'
+    | 'orc'
+    | 'primordial'
+    | 'sylvan'
+    | 'terran'
+    | 'cant'
+    | 'undercommon';
+
+  export type CharacterFlagArr = [
+    'diamondSoul',
+    'elvenAccuracy',
+    'halflingLucky',
+    'initiativeAdv',
+    'initiativeAlert',
+    'jackOfAllTrades',
+    'observantFeat',
+    'powerfulBuild',
+    'reliableTalent',
+    'remarkableAthlete',
+    'weaponCriticalThreshold',
+    'spellCriticalThreshold',
+    'meleeCriticalDamageDice'
+  ];
+  export type CharacterFlag = CharacterFlagArr[number];
 }
 
 declare global {
@@ -231,11 +332,36 @@ declare global {
       rollItemMacro: typeof macros.rollItemMacro;
     };
 
-    // TODO: Handle sheet registering/unregistering.
     CONFIG: {
       DND5E: DND5e;
       Actor: {
         entityClass: Actor5e;
+        sheetClasses: {
+          character: {
+            'dnd5e.ActorSheet5eCharacter': {
+              id: 'dnd5e.ActorSheet5eCharacter';
+              default: boolean;
+              cls: ActorSheet5eCharacter;
+              label: string;
+            };
+          };
+          npc: {
+            'dnd5e.ActorSheet5eNPC': {
+              id: 'dnd5e.ActorSheet5eNPC';
+              default: boolean;
+              cls: ActorSheet5eNPC;
+              label: string;
+            };
+          };
+          vehicle: {
+            'dnd5e.ActorSheet5eVehicle': {
+              id: 'dnd5e.ActorSheet5eVehicle';
+              default: boolean;
+              cls: ActorSheet5eVehicle;
+              label: string;
+            };
+          };
+        };
       };
 
       Item: {

--- a/dnd5e/dnd5e.d.ts
+++ b/dnd5e/dnd5e.d.ts
@@ -1,9 +1,276 @@
 import '@league-of-foundry-developers/foundry-vtt-types';
 
-interface DND5e {}
+// Import Modules
+import type { DND5e } from './module/config';
+import './module/settings';
+import './module/templates';
+import type { _getInitiativeFormula } from './module/combat';
+import type { measureDistances, getBarAttribute } from './module/canvas';
+
+// Import Entities
+import type Actor5e from './module/actor/entity';
+import type Item5e from './module/item/entity';
+
+// Import Applications
+import type AbilityTemplate from './module/pixi/ability-template';
+import type AbilityUseDialog from './module/apps/ability-use-dialog';
+import type ActorSheetFlags from './module/apps/actor-flags';
+import type ActorSheet5eCharacter from './module/actor/sheets/character';
+import type ActorSheet5eNPC from './module/actor/sheets/npc';
+import type ActorSheet5eVehicle from './module/actor/sheets/vehicle';
+import type ItemSheet5e from './module/item/sheet';
+import type ShortRestDialog from './module/apps/short-rest';
+import type TraitSelector from './module/apps/trait-selector';
+import type ActorMovementConfig from './module/apps/movement-config';
+import './module/apps/senses-config';
+
+// Import Helpers
+import './module/chat';
+import type * as dice from './module/dice';
+import type * as macros from './module/macros';
+import type * as migrations from './module/migration';
+
+declare namespace DND5e {
+  export type PhysicalAbility = 'str' | 'dex' | 'con';
+  export type MentalAbility = 'int' | 'wis' | 'cha';
+  export type AbilityType = PhysicalAbility | MentalAbility;
+
+  export type ItemType =
+    | 'weapon'
+    | 'equipment'
+    | 'consumable'
+    | 'tool'
+    | 'loot'
+    | 'class'
+    | 'spell'
+    | 'feat'
+    | 'backpack';
+
+  export type TargetUnitType = 'none' | 'self' | 'touch' | 'special' | 'any' | 'ft' | 'miles';
+  export type DamageType =
+    | 'acid'
+    | 'bludgeoning'
+    | 'cold'
+    | 'fire'
+    | 'force'
+    | 'lightning'
+    | 'necrotic'
+    | 'piercing'
+    | 'poison'
+    | 'psychic'
+    | 'radiant'
+    | 'slashing'
+    | 'thunder'
+    | 'none';
+
+  export type AttackType = 'mwak' | 'rwak' | 'rsak' | 'msak';
+  export type ActionType = AttackType | 'save';
+  export type ActivationType = 'action' | 'bonus' | 'reaction' | 'special';
+  export type ToolProficiency =
+    | 'herb'
+    | 'art'
+    | 'disg'
+    | 'forg'
+    | 'game'
+    | 'music'
+    | 'navg'
+    | 'pois'
+    | 'thief'
+    | 'vehicle';
+
+  export type TargetType =
+    | 'ally'
+    | 'cone'
+    | 'creature'
+    | 'cube'
+    | 'cylinder'
+    | 'enemy'
+    | 'line'
+    | 'none'
+    | 'object'
+    | 'radius'
+    | 'self'
+    | 'space'
+    | 'sphere'
+    | 'square'
+    | 'wall';
+
+  export type DurationType =
+    | 'days'
+    | 'hours'
+    | 'instantaneous'
+    | 'minutes'
+    | 'months'
+    | 'permanent'
+    | 'rounds'
+    | 'special'
+    | 'turns'
+    | 'years';
+
+  export type WeaponType = 'simpleM' | 'martialM' | 'simpleR' | 'martialR' | 'natural' | 'improv' | 'siege';
+
+  export interface Skill {
+    value: number;
+    ability: DND5e.AbilityType;
+    bonus: number;
+    mod: number;
+    passive: number;
+    prof: number;
+    total: number;
+  }
+
+  export type Skills =
+    | 'acr'
+    | 'ani'
+    | 'arc'
+    | 'ath'
+    | 'dec'
+    | 'his'
+    | 'ins'
+    | 'itm'
+    | 'inv'
+    | 'med'
+    | 'nat'
+    | 'prc'
+    | 'prf'
+    | 'per'
+    | 'rel'
+    | 'slt'
+    | 'ste'
+    | 'sur';
+
+  export type AbilityBonus = {
+    check: string;
+    save: string;
+    skill: string;
+  };
+
+  export type AttackBonus = {
+    attack: string;
+    damage: string;
+  };
+
+  export type SaveBonus = {
+    dc: number;
+  };
+
+  export interface Ability {
+    value: number;
+    proficient: number;
+    mod: number;
+    save: number;
+    prof: number;
+  }
+
+  export type MovementType = 'burrow' | 'climb' | 'fly' | 'swim' | 'walk' | 'hover';
+
+  export type Senses = 'darkvision' | 'blindsense' | 'tremorsense' | 'truesight' | 'special';
+
+  export type Currencies = 'cp' | 'sp' | 'gp' | 'ep' | 'pp';
+
+  export type School = 'abj' | 'con' | 'div' | 'enc' | 'evo' | 'ill' | 'nec' | 'trs';
+  export type Preparation = 'prepared' | 'always';
+
+  export type SpellLevel = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+  export type SpellType = `spell${SpellLevel}` | 'pact';
+
+  export type Resources = 'primary' | 'secondary' | 'tertiary';
+
+  export type ConsumeType = string;
+  export type ConsumeTarget = string;
+
+  export type ArmorType = 'light' | 'medium' | 'heavy';
+
+  export type Size = 'grg' | 'huge' | 'lg' | 'med' | 'sm' | 'tiny';
+  export type Alignment = 'ce' | 'cg' | 'cn' | 'le' | 'lg' | 'ln' | 'ne' | 'ng' | 'tn';
+
+  export type ConditionType =
+    | 'blinded'
+    | 'charmed'
+    | 'deafened'
+    | 'diseased'
+    | 'exhaustion'
+    | 'frightened'
+    | 'grappled'
+    | 'incapacitated'
+    | 'invisible'
+    | 'paralyzed'
+    | 'petrified'
+    | 'poisoned'
+    | 'prone'
+    | 'restrained'
+    | 'stunned'
+    | 'unconscious';
+}
 
 declare global {
   export interface Game {
-    dnd5e: DND5e;
+    dnd5e: {
+      applications: {
+        AbilityUseDialog: AbilityUseDialog;
+        ActorSheetFlags: ActorSheetFlags;
+        ActorSheet5eCharacter: ActorSheet5eCharacter;
+        ActorSheet5eNPC: ActorSheet5eNPC;
+        ActorSheet5eVehicle: ActorSheet5eVehicle;
+        ItemSheet5e: ItemSheet5e;
+        ShortRestDialog: ShortRestDialog;
+        TraitSelector: TraitSelector;
+        ActorMovementConfig: ActorMovementConfig;
+      };
+      canvas: {
+        AbilityTemplate: AbilityTemplate;
+      };
+      config: DND5e;
+      dice: typeof dice;
+      entities: {
+        Actor5e: Actor5e;
+        Item5e: Item5e;
+      };
+      macros: typeof macros;
+      migrations: typeof migrations;
+      rollItemMacro: typeof macros.rollItemMacro;
+    };
+
+    // TODO: Handle sheet registering/unregistering.
+    CONFIG: {
+      DND5E: DND5e;
+      Actor: {
+        entityClass: Actor5e;
+      };
+
+      Item: {
+        entityClass: Item5e;
+      };
+
+      time: {
+        roundTime: number;
+      };
+
+      MeasuredTemplate: {
+        defaults: {
+          angle: number;
+        };
+      };
+
+      Combat: {
+        initiative: {
+          formula: string;
+        };
+      };
+    };
+
+    Combat: {
+      _getInitiativeFormula: typeof _getInitiativeFormula;
+    };
+
+    SquareGrid: {
+      measureDistances: typeof measureDistances;
+    };
+
+    Token: {
+      getBarAttribute: typeof getBarAttribute;
+    };
   }
 }
+
+export default DND5e;

--- a/dnd5e/dnd5e.d.ts
+++ b/dnd5e/dnd5e.d.ts
@@ -302,6 +302,105 @@ declare namespace DND5e {
     'meleeCriticalDamageDice'
   ];
   export type CharacterFlag = CharacterFlagArr[number];
+
+  export type Segment = { ray: { dx: number; dy: number } };
+
+  export type Subclasses = {
+    barbarian: [
+      'path-of-the-ancestral-guardian',
+      'path-of-the-battlerager',
+      'path-of-the-berserker',
+      'path-of-the-juggernaut',
+      'path-of-the-storm-herald',
+      'path-of-the-totem-warrior',
+      'path-of-the-zealot'
+    ];
+    bard: ['college-of-glamour', 'college-of-lore', 'college-of-swords', 'college-of-valor', 'college-of-whispers'];
+    cleric: [
+      'ambition-domain',
+      'arcana-domain',
+      'blood-domain',
+      'death-domain',
+      'forge-domain',
+      'grave-domain',
+      'knowledge-domain',
+      'life-domain',
+      'light-domain',
+      'nature-domain',
+      'order-domain',
+      'solidarity-domain',
+      'strength-domain',
+      'tempest-domain',
+      'trickery-domain',
+      'war-domain',
+      'zeal-domain'
+    ];
+    druid: [
+      'circle-of-dreams',
+      'circle-of-the-land',
+      'circle-of-the-moon',
+      'circle-of-the-shepherd',
+      'circle-of-spores'
+    ];
+    fighter: [
+      'arcane-archer',
+      'banneret',
+      'battle-master',
+      'cavalier',
+      'champion',
+      'echo-knight',
+      'eldritch-knight',
+      'samurai'
+    ];
+    monk: [
+      'way-of-the-cobalt-soul',
+      'way-of-the-drunken-master',
+      'way-of-the-elements',
+      'way-of-the-kensei',
+      'way-of-the-long-death',
+      'way-of-the-open-hand',
+      'way-of-the-shadow',
+      'way-of-the-sun-soul'
+    ];
+    paladin: [
+      'oath-of-the-ancients',
+      'oath-of-conquest',
+      'oath-of-the-crown',
+      'oath-of-devotion',
+      'oathbreaker',
+      'oath-of-redemption',
+      'oath-of-vengeance'
+    ];
+    ranger: ['beast-master', 'gloom-stalker', 'horizon-walker', 'hunter', 'monster-slayer'];
+    rogue: ['arcane-trickster', 'assassin', 'inquisitive', 'mastermind', 'scout', 'swashbuckler', 'thief'];
+    sorcerer: [
+      'draconic-bloodline',
+      'divine-soul',
+      'pyromancer',
+      'runechild',
+      'shadow-magic',
+      'storm-sorcery',
+      'wild-magic'
+    ];
+    warlock: ['the-archfey', 'the-celestial', 'the-fiend', 'the-hexblade', 'the-oldone', 'the-undying'];
+    wizard: [
+      'school-of-abjuration',
+      'school-of-bladesinging',
+      'school-of-chronurgy-magic',
+      'school-of-conjuration',
+      'school-of-divination',
+      'school-of-enchantment',
+      'school-of-evocation',
+      'school-of-graviturgy-magic',
+      'school-of-illusion',
+      'school-of-necromancy',
+      'school-of-transmutation',
+      'school-of-war-magic'
+    ];
+  };
+  export type Class = keyof Subclasses;
+
+  export type RollMode = 'roll' | 'gmroll' | 'blindroll' | 'selfroll';
 }
 
 declare global {

--- a/dnd5e/module/actor/entity.d.ts
+++ b/dnd5e/module/actor/entity.d.ts
@@ -1,0 +1,607 @@
+import '@league-of-foundry-developers/foundry-vtt-types';
+
+import type DND5e from '../../dnd5e';
+import type Item5e from '../item/entity';
+
+declare class Actor5e extends Actor<Actor5e.Data, Item5e> {
+  get isPolymorphed(): boolean;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Return the amount of experience required to gain a certain character level.
+   * @param level {Number}  The desired level
+   * @return {Number}       The XP required
+   */
+  getLevelExp(level: number): number;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Return the amount of experience granted by killing a creature of a certain CR.
+   * @param cr {Number}     The creature's challenge rating
+   * @return {Number}       The amount of experience granted per kill
+   */
+  getCRExp(cr: number): number;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Return the features which a character is awarded for each class level
+   * @param {string} className        The class name being added
+   * @param {string} subclassName     The subclass of the class being added, if any
+   * @param {number} level            The number of levels in the added class
+   * @param {number} priorLevel       The previous level of the added class
+   * @return {Promise<Item5e[]>}     Array of Item5e entities
+   */
+  static getClassFeatures({
+    className,
+    subclassName,
+    level,
+    priorLevel
+  }: {
+    className?: string;
+    subclassName?: string;
+    level: number;
+    priorLevel: number;
+  }): Promise<Item5e[]>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create additional class features in the Actor when a class item is updated.
+   * @private
+   */
+  _createClassFeatures(updated: Actor5e.ClassFeatureUpdate | Actor5e.ClassFeatureUpdate[]): Promise<Item5e[]>;
+
+  /* -------------------------------------------- */
+  /*  Data Preparation Helpers                    */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare Character type specific data
+   */
+  _prepareCharacterData(actorData: Actor5e.Data): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare NPC type specific data
+   */
+  _prepareNPCData(actorData: Actor5e.Data): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare vehicle type-specific data
+   * @param actorData
+   * @private
+   */
+  _prepareVehicleData(actorData: Actor5e.Data): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare skill checks.
+   * @param actorData
+   * @param bonuses Global bonus data.
+   * @param checkBonus Ability check specific bonus.
+   * @param originalSkills A transformed actor's original actor's skills.
+   * @private
+   */
+  _prepareSkills(
+    actorData: Actor5e.Data,
+    bonuses: DND5e.AbilityBonus,
+    checkBonus: number,
+    originalSkills: Record<DND5e.Skills, DND5e.Skill>
+  ): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare data related to the spell-casting capabilities of the Actor
+   * @private
+   */
+  _computeSpellcastingProgression(actorData: Actor5e.Data): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Compute the level and percentage of encumbrance for an Actor.
+   *
+   * Optionally include the weight of carried currency across all denominations by applying the standard rule
+   * from the PHB pg. 143
+   * @param {Object} actorData      The data object for the Actor being rendered
+   * @returns {{max: number, value: number, pct: number}}  An object describing the character's encumbrance level
+   * @private
+   */
+  _computeEncumbrance(actorData: Actor5e.Data): Actor5e.Encumbrance;
+
+  /* -------------------------------------------- */
+  /*  Socket Listeners and Handlers
+  /* -------------------------------------------- */
+
+  /**
+   * A temporary shim function which will eventually (in core fvtt version 0.8.0+) be migrated to the new abstraction layer
+   * @param itemData
+   * @param options
+   * @private
+   */
+  _preCreateOwnedItem(itemData: Item5e.Data, options: any): void;
+
+  /* -------------------------------------------- */
+  /*  Gameplay Mechanics                          */
+  /* -------------------------------------------- */
+
+  /**
+   * Apply a certain amount of damage or healing to the health pool for Actor
+   * @param {number} amount       An amount of damage (positive) or healing (negative) to sustain
+   * @param {number} multiplier   A multiplier which allows for resistance, vulnerability, or healing
+   * @return {Promise<Actor>}     A Promise which resolves once the damage has been applied
+   */
+  applyDamage(amount: number, multiplier: number): Promise<this>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Roll a Skill Check
+   * Prompt the user for input regarding Advantage/Disadvantage and any Situational Bonus
+   * @param {string} skillId      The skill id (e.g. "ins")
+   * @param {Object} options      Options which configure how the skill check is rolled
+   * @return {Promise<Roll>}      A Promise which resolves to the created Roll instance
+   */
+  rollSkill<Options extends Object>(skillId: string, options: Options): Promise<Roll<Options>>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Roll a generic ability test or saving throw.
+   * Prompt the user for input on which variety of roll they want to do.
+   * @param {String}abilityId     The ability id (e.g. "str")
+   * @param {Object} options      Options which configure how ability tests or saving throws are rolled
+   */
+  rollAbility<Options extends Object>(abilityId: string, options: Options): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Roll an Ability Test
+   * Prompt the user for input regarding Advantage/Disadvantage and any Situational Bonus
+   * @param {String} abilityId    The ability ID (e.g. "str")
+   * @param {Object} options      Options which configure how ability tests are rolled
+   * @return {Promise<Roll>}      A Promise which resolves to the created Roll instance
+   */
+  rollAbilityTest<Options extends Object>(abilityId: string, options: Options): Promise<Roll<Options>>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Roll an Ability Saving Throw
+   * Prompt the user for input regarding Advantage/Disadvantage and any Situational Bonus
+   * @param {String} abilityId    The ability ID (e.g. "str")
+   * @param {Object} options      Options which configure how ability tests are rolled
+   * @return {Promise<Roll>}      A Promise which resolves to the created Roll instance
+   */
+  rollAbilitySave<Options extends Object>(abilityId: string, options: Options): Promise<Roll<Options>>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Perform a death saving throw, rolling a d20 plus any global save bonuses
+   * @param {Object} options        Additional options which modify the roll
+   * @return {Promise<Roll|null>}   A Promise which resolves to the Roll instance
+   */
+  rollDeathSave<Options extends Object>(options: Options): Promise<Roll<Options> | null>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Roll a hit die of the appropriate type, gaining hit points equal to the die roll plus your CON modifier
+   * @param {string} [denomination]   The hit denomination of hit die to roll. Example "d8".
+   *                                  If no denomination is provided, the first available HD will be used
+   * @param {boolean} [dialog]        Show a dialog prompt for configuring the hit die roll?
+   * @return {Promise<Roll|null>}     The created Roll instance, or null if no hit die was rolled
+   */
+  rollHitDie(denomination: `d${number}`, { dialog }: { dialog: boolean }): Promise<Roll | null>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Cause this Actor to take a Short Rest
+   * During a Short Rest resources and limited item uses may be recovered
+   * @param {boolean} dialog  Present a dialog window which allows for rolling hit dice as part of the Short Rest
+   * @param {boolean} chat    Summarize the results of the rest workflow as a chat message
+   * @param {boolean} autoHD  Automatically spend Hit Dice if you are missing 3 or more hit points
+   * @param {boolean} autoHDThreshold   A number of missing hit points which would trigger an automatic HD roll
+   * @return {Promise}        A Promise which resolves once the short rest workflow has completed
+   */
+  shortRest({
+    dialog,
+    chat,
+    autoHD,
+    autoHDThreshold
+  }: {
+    dialog: boolean;
+    chat: boolean;
+    autoHD: boolean;
+    autoHDThreshold: boolean;
+  }): Promise<Actor5e.RestData | undefined>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Take a long rest, recovering HP, HD, resources, and spell slots
+   * @param {boolean} dialog  Present a confirmation dialog window whether or not to take a long rest
+   * @param {boolean} chat    Summarize the results of the rest workflow as a chat message
+   * @param {boolean} newDay  Whether the long rest carries over to a new day
+   * @return {Promise}        A Promise which resolves once the long rest workflow has completed
+   */
+  longRest({
+    dialog,
+    chat,
+    newDay
+  }: {
+    dialog: boolean;
+    chat: boolean;
+    newDay: boolean;
+  }): Promise<Actor5e.RestData | undefined>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Convert all carried currency to the highest possible denomination to reduce the number of raw coins being
+   * carried by an Actor.
+   * @return {Promise<Actor5e>}
+   */
+  convertCurrency(): Promise<this>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Transform this Actor into another one.
+   *
+   * @param {Actor} target The target Actor.
+   * @param {boolean} [keepPhysical] Keep physical abilities (str, dex, con)
+   * @param {boolean} [keepMental] Keep mental abilities (int, wis, cha)
+   * @param {boolean} [keepSaves] Keep saving throw proficiencies
+   * @param {boolean} [keepSkills] Keep skill proficiencies
+   * @param {boolean} [mergeSaves] Take the maximum of the save proficiencies
+   * @param {boolean} [mergeSkills] Take the maximum of the skill proficiencies
+   * @param {boolean} [keepClass] Keep proficiency bonus
+   * @param {boolean} [keepFeats] Keep features
+   * @param {boolean} [keepSpells] Keep spells
+   * @param {boolean} [keepItems] Keep items
+   * @param {boolean} [keepBio] Keep biography
+   * @param {boolean} [keepVision] Keep vision
+   * @param {boolean} [transformTokens] Transform linked tokens too
+   */
+  transformInto(
+    target: Actor,
+    {
+      keepPhysical,
+      keepMental,
+      keepSaves,
+      keepSkills,
+      mergeSaves,
+      mergeSkills,
+      keepClass,
+      keepFeats,
+      keepSpells,
+      keepItems,
+      keepBio,
+      keepVision,
+      transformTokens
+    }: {
+      keepPhysical: boolean;
+      keepMental: boolean;
+      keepSaves: boolean;
+      keepSkills: boolean;
+      mergeSaves: boolean;
+      mergeSkills: boolean;
+      keepClass: boolean;
+      keepFeats: boolean;
+      keepSpells: boolean;
+      keepItems: boolean;
+      keepBio: boolean;
+      keepVision: boolean;
+      transformTokens: boolean;
+    }
+  ): ReturnType<Scene['updateEmbeddedEntity']> | undefined;
+
+  /* -------------------------------------------- */
+
+  /**
+   * If this actor was transformed with transformTokens enabled, then its
+   * active tokens need to be returned to their original state. If not, then
+   * we can safely just delete this actor.
+   */
+  revertOriginalForm(): Promise<Actor5e | undefined>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add additional system-specific sidebar directory context menu options for Actor entities
+   * @param {jQuery} html         The sidebar HTML
+   * @param {Array} entryOptions  The default array of context menu options
+   */
+  static addDirectoryContextOptions<Options extends Array<any>>(html: JQuery, entryOptions: Options[]): void;
+
+  /* -------------------------------------------- */
+  /*  DEPRECATED METHODS                          */
+  /* -------------------------------------------- */
+
+  /**
+   * @deprecated since dnd5e 0.97
+   */
+  getSpellDC(ability: DND5e.AbilityType): number;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Cast a Spell, consuming a spell slot of a certain level
+   * @param {Item5e} item   The spell being cast by the actor
+   * @param {Event} event   The originating user interaction which triggered the cast
+   * @deprecated since dnd5e 1.2.0
+   */
+  useSpell(item: Item5e, { configureDialog }: { configureDialog: boolean }): Promise<Roll>;
+}
+
+declare namespace Actor5e {
+  type ClassFeatureUpdate = {
+    _id: string;
+    data?: {
+      subclass?: string;
+      levels?: number;
+    };
+  };
+
+  export type Encumbrance = {
+    value: number;
+    max: number;
+    pct: number;
+    encumbered: boolean;
+  };
+
+  export type RestData = {
+    dhd: number;
+    dhp: number;
+    updateData: Record<string, number>;
+    updateItems: { _id: string; [K: string]: unknown };
+    newDay: boolean;
+  };
+
+  export interface Data extends Actor.Data<Data.Data, Item5e.Data> {
+    folder: string;
+    img: string;
+    name: string;
+    permission: Entity.Permission;
+    sort: number;
+  }
+
+  export namespace Templates {
+    type TraitData<Trait> = {
+      values: Trait[];
+      custom: string;
+    };
+
+    export interface Common {
+      abilities: Record<
+        DND5e.AbilityType,
+        {
+          value: number;
+          proficient: number;
+        }
+      >;
+      attributes: {
+        ac: {
+          value: number;
+        };
+        hp: {
+          value: number;
+          min: number;
+          max: number;
+          temp: number;
+          tempmax: number;
+        };
+        init: {
+          value: number;
+          bonus: number;
+        };
+        movement: Record<DND5e.MovementType, number> & {
+          hover: boolean;
+          units: string;
+        };
+      };
+      details: {
+        biography: {
+          value: string;
+          public: string;
+        };
+      };
+      traits: {
+        size: DND5e.Size;
+
+        // Damage immunity
+        di: TraitData<DND5e.DamageType>;
+
+        // Damage resistance
+        dr: TraitData<DND5e.DamageType>;
+
+        // Damage vulnerability
+        dv: TraitData<DND5e.DamageType>;
+
+        // Condition immunity
+        ci: TraitData<DND5e.DamageType>;
+      };
+      currency: Record<DND5e.Currencies, number>;
+    }
+
+    export interface Creature {
+      attributes: {
+        senses: Record<DND5e.Senses, number> & {
+          special: string;
+          units: string;
+        };
+        spellcasting: DND5e.AbilityType;
+        details: {
+          alignment: DND5e.Alignment;
+          race: string;
+        };
+        skills: Record<
+          DND5e.Skills,
+          {
+            value: number;
+            ability: DND5e.Ability;
+          }
+        >;
+        traits: {
+          languages: TraitData<string>;
+        };
+        spells: Record<DND5e.SpellType, { value: number; override: number | null }>;
+        bonuses: Record<DND5e.AttackType, DND5e.AttackBonus> & {
+          abilities: DND5e.AbilityBonus;
+          spell: DND5e.SaveBonus;
+        };
+      };
+    }
+
+    export interface Character {
+      attributes: {
+        death: {
+          success: number;
+          failure: number;
+        };
+
+        encumbrance: {
+          value: number | null;
+          max: number | null;
+        };
+
+        exhaustion: number;
+        inspiration: boolean;
+      };
+
+      details: {
+        background: string;
+        xp: {
+          value: number;
+          min: number;
+          max: number;
+        };
+        appearance: string;
+        trait: string;
+        ideal: string;
+        bond: string;
+        flaw: string;
+      };
+
+      resources: Record<
+        DND5e.Resources,
+        {
+          value: number;
+          max: number;
+          sr: number;
+          lr: number;
+        }
+      >;
+
+      traits: {
+        weaponProf: TraitData<string>;
+        armorProf: TraitData<string>;
+        toolProf: TraitData<DND5e.ToolProficiency>;
+      };
+    }
+
+    export interface NPC {
+      details: {
+        type: string;
+        environment: string;
+        cr: number;
+        spellLevel: number;
+        xp: {
+          value: number;
+        };
+        source: string;
+      };
+      resources: {
+        // Legendary action
+        legact: {
+          value: number;
+          max: number;
+        };
+
+        // Legendary resistance
+        legres: {
+          value: number;
+          max: number;
+        };
+
+        // Lair action
+        lair: {
+          value: number;
+          initiative: number;
+        };
+      };
+    }
+
+    export interface Vehicle {
+      abilities: Record<
+        DND5e.MentalAbility,
+        {
+          value: number;
+        }
+      >;
+      attributes: {
+        ac: {
+          value: number | null;
+          motionless: string;
+        };
+        actions: {
+          stations: boolean;
+          value: number;
+          thresholds: {
+            // TODO: Check thresholds
+            '2': null;
+            '1': null;
+            '0': null;
+          };
+        };
+        hp: {
+          value: number | null;
+          max: number | null;
+          dt: number | null;
+          mt: number | null;
+        };
+        capacity: {
+          creature: string;
+          cargo: 0;
+        };
+      };
+      traits: {
+        size: DND5e.Size;
+        dimensions: string;
+        di: {
+          value: DND5e.DamageType[];
+        };
+        ci: {
+          value: DND5e.ConditionType[];
+        };
+      };
+      cargo: {
+        // TODO: Check crew/passengers
+        crew: [];
+        passengers: [];
+      };
+    }
+  }
+
+  export namespace Data {
+    export type Character = Templates.Common & Templates.Creature & Templates.Character;
+    export type NPC = Templates.Common & Templates.Creature & Templates.NPC;
+    export type Vehicle = Templates.Common & Templates.Vehicle;
+
+    export type Data = Character | NPC | Vehicle;
+  }
+}
+
+export default Actor5e;

--- a/dnd5e/module/actor/entity.d.ts
+++ b/dnd5e/module/actor/entity.d.ts
@@ -93,7 +93,7 @@ declare class Actor5e extends Actor<Actor5e.Data, Item5e> {
     actorData: Actor5e.Data,
     bonuses: DND5e.AbilityBonus,
     checkBonus: number,
-    originalSkills: Record<DND5e.Skills, DND5e.Skill>
+    originalSkills: Record<DND5e.SkillType, DND5e.Skill>
   ): void;
 
   /* -------------------------------------------- */
@@ -291,21 +291,7 @@ declare class Actor5e extends Actor<Actor5e.Data, Item5e> {
       keepBio,
       keepVision,
       transformTokens
-    }: {
-      keepPhysical: boolean;
-      keepMental: boolean;
-      keepSaves: boolean;
-      keepSkills: boolean;
-      mergeSaves: boolean;
-      mergeSkills: boolean;
-      keepClass: boolean;
-      keepFeats: boolean;
-      keepSpells: boolean;
-      keepItems: boolean;
-      keepBio: boolean;
-      keepVision: boolean;
-      transformTokens: boolean;
-    }
+    }: Record<DND5e.PolymorphSetting | 'transformTokens', boolean>
   ): ReturnType<Scene['updateEmbeddedEntity']> | undefined;
 
   /* -------------------------------------------- */
@@ -409,7 +395,7 @@ declare namespace Actor5e {
         };
         movement: Record<DND5e.MovementType, number> & {
           hover: boolean;
-          units: string;
+          units: DND5e.Unit;
         };
       };
       details: {
@@ -433,14 +419,14 @@ declare namespace Actor5e {
         // Condition immunity
         ci: TraitData<DND5e.DamageType>;
       };
-      currency: Record<DND5e.Currencies, number>;
+      currency: Record<DND5e.Currency, number>;
     }
 
     export interface Creature {
       attributes: {
         senses: Record<DND5e.Senses, number> & {
           special: string;
-          units: string;
+          units: DND5e.Unit;
         };
         spellcasting: DND5e.AbilityType;
         details: {
@@ -448,7 +434,7 @@ declare namespace Actor5e {
           race: string;
         };
         skills: Record<
-          DND5e.Skills,
+          DND5e.SkillType,
           {
             value: number;
             ability: DND5e.Ability;
@@ -506,7 +492,7 @@ declare namespace Actor5e {
       >;
 
       traits: {
-        weaponProf: TraitData<string>;
+        weaponProf: TraitData<DND5e.WeaponProficiency>;
         armorProf: TraitData<string>;
         toolProf: TraitData<DND5e.ToolProficiency>;
       };

--- a/dnd5e/module/actor/sheets/character.d.ts
+++ b/dnd5e/module/actor/sheets/character.d.ts
@@ -1,19 +1,3 @@
-type Details = {
-  details: {
-    background: string;
-    xp: {
-      value: number;
-      min: number;
-      max: number;
-    };
-    appearance: string;
-    trait: string;
-    ideal: string;
-    bond: string;
-    flaw: string;
-  };
-};
-
 declare class ActorSheet5eCharacter {}
 
 export default ActorSheet5eCharacter;

--- a/dnd5e/module/actor/sheets/character.d.ts
+++ b/dnd5e/module/actor/sheets/character.d.ts
@@ -1,0 +1,19 @@
+type Details = {
+  details: {
+    background: string;
+    xp: {
+      value: number;
+      min: number;
+      max: number;
+    };
+    appearance: string;
+    trait: string;
+    ideal: string;
+    bond: string;
+    flaw: string;
+  };
+};
+
+declare class ActorSheet5eCharacter {}
+
+export default ActorSheet5eCharacter;

--- a/dnd5e/module/actor/sheets/npc.d.ts
+++ b/dnd5e/module/actor/sheets/npc.d.ts
@@ -1,0 +1,3 @@
+declare class ActorSheet5eNPC {}
+
+export default ActorSheet5eNPC;

--- a/dnd5e/module/actor/sheets/vehicle.d.ts
+++ b/dnd5e/module/actor/sheets/vehicle.d.ts
@@ -1,0 +1,3 @@
+declare class ActorSheet5eVehicle {}
+
+export default ActorSheet5eVehicle;

--- a/dnd5e/module/apps/ability-use-dialog.d.ts
+++ b/dnd5e/module/apps/ability-use-dialog.d.ts
@@ -1,0 +1,5 @@
+import '@league-of-foundry-developers/foundry-vtt-types';
+
+declare class AbilityUseDialog {}
+
+export default AbilityUseDialog;

--- a/dnd5e/module/apps/actor-flags.d.ts
+++ b/dnd5e/module/apps/actor-flags.d.ts
@@ -1,0 +1,3 @@
+declare class ActorSheetFlags {}
+
+export default ActorSheetFlags;

--- a/dnd5e/module/apps/movement-config.d.ts
+++ b/dnd5e/module/apps/movement-config.d.ts
@@ -1,0 +1,3 @@
+declare class ActorMovementConfig {}
+
+export default ActorMovementConfig;

--- a/dnd5e/module/apps/senses-config.d.ts
+++ b/dnd5e/module/apps/senses-config.d.ts
@@ -1,0 +1,3 @@
+declare class ActorMovementConfig {}
+
+export default ActorMovementConfig;

--- a/dnd5e/module/apps/short-rest.d.ts
+++ b/dnd5e/module/apps/short-rest.d.ts
@@ -1,0 +1,3 @@
+declare class ShortRestDialog {}
+
+export default ShortRestDialog;

--- a/dnd5e/module/apps/trait-selector.d.ts
+++ b/dnd5e/module/apps/trait-selector.d.ts
@@ -1,0 +1,3 @@
+declare class TraitSelector {}
+
+export default TraitSelector;

--- a/dnd5e/module/canvas.d.ts
+++ b/dnd5e/module/canvas.d.ts
@@ -1,0 +1,5 @@
+import '@league-of-foundry-developers/foundry-vtt-types';
+
+export declare function measureDistances(...args: any[]): any;
+
+export declare function getBarAttribute(...args: any[]): any;

--- a/dnd5e/module/canvas.d.ts
+++ b/dnd5e/module/canvas.d.ts
@@ -1,9 +1,7 @@
 import '@league-of-foundry-developers/foundry-vtt-types';
 
 /** @override */
-export declare function measureDistances(
-  ...args: Parameters<BaseGrid['measureDistances']>
-): ReturnType<BaseGrid['measureDistances']>;
+export declare const measureDistances: BaseGrid['measureDistances'];
 
 /* -------------------------------------------- */
 
@@ -11,6 +9,4 @@ export declare function measureDistances(
  * Hijack Token health bar rendering to include temporary and temp-max health in the bar display
  * TODO: This should probably be replaced with a formal Token class extension
  */
-export declare function getBarAttribute(
-  ...args: Parameters<Token['getBarAttribute']>
-): ReturnType<Token['getBarAttribute']>;
+export declare const getBarAttribute: Token['getBarAttribute'];

--- a/dnd5e/module/canvas.d.ts
+++ b/dnd5e/module/canvas.d.ts
@@ -1,5 +1,16 @@
 import '@league-of-foundry-developers/foundry-vtt-types';
 
-export declare function measureDistances(...args: any[]): any;
+/** @override */
+export declare function measureDistances(
+  ...args: Parameters<BaseGrid['measureDistances']>
+): ReturnType<BaseGrid['measureDistances']>;
 
-export declare function getBarAttribute(...args: any[]): any;
+/* -------------------------------------------- */
+
+/**
+ * Hijack Token health bar rendering to include temporary and temp-max health in the bar display
+ * TODO: This should probably be replaced with a formal Token class extension
+ */
+export declare function getBarAttribute(
+  ...args: Parameters<Token['getBarAttribute']>
+): ReturnType<Token['getBarAttribute']>;

--- a/dnd5e/module/classFeatures.d.ts
+++ b/dnd5e/module/classFeatures.d.ts
@@ -1,1 +1,11 @@
-export declare class ClassFeatures {}
+import DND5e from '../dnd5e';
+
+export declare type ClassFeatures = {
+  [K in keyof DND5e.Subclasses]: { features: Record<`${number}`, string[]> } & {
+    [SK in DND5e.Subclasses[K][number]]: {
+      label: string;
+      source: string;
+      features: Record<`${number}`, string[]>;
+    };
+  };
+};

--- a/dnd5e/module/classFeatures.d.ts
+++ b/dnd5e/module/classFeatures.d.ts
@@ -1,0 +1,1 @@
+export declare class ClassFeatures {}

--- a/dnd5e/module/combat.d.ts
+++ b/dnd5e/module/combat.d.ts
@@ -1,3 +1,9 @@
 import '@league-of-foundry-developers/foundry-vtt-types';
 
-export declare function _getInitiativeFormula(...args: any[]): any;
+/**
+ * Override the default Initiative formula to customize special behaviors of the system.
+ * Apply advantage, proficiency, or bonuses where appropriate
+ * Apply the dexterity score as a decimal tiebreaker if requested
+ * See Combat._getInitiativeFormula for more detail.
+ */
+export declare function _getInitiativeFormula(combatant: Combat.Combatant): string | string[];

--- a/dnd5e/module/combat.d.ts
+++ b/dnd5e/module/combat.d.ts
@@ -1,0 +1,3 @@
+import '@league-of-foundry-developers/foundry-vtt-types';
+
+export declare function _getInitiativeFormula(...args: any[]): any;

--- a/dnd5e/module/config.d.ts
+++ b/dnd5e/module/config.d.ts
@@ -1,4 +1,5 @@
 import '@league-of-foundry-developers/foundry-vtt-types';
+
 import { ClassFeatures } from './classFeatures';
 import type DND5e from '../dnd5e';
 

--- a/dnd5e/module/config.d.ts
+++ b/dnd5e/module/config.d.ts
@@ -1,4 +1,335 @@
 import '@league-of-foundry-developers/foundry-vtt-types';
+import { ClassFeatures } from './classFeatures';
+import type DND5e from '../dnd5e';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-declare interface DND5e {}
+declare interface DND5e {
+  // ASCII Artwork
+  ASCII: string;
+
+  /**
+   * The set of Ability Scores used within the system
+   * @type {Object}
+   */
+  abilities: Record<DND5e.AbilityType, string>;
+  abilityAbbreviations: Record<DND5e.AbilityType, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Character alignment options
+   * @type {Object}
+   */
+  alignments: Record<DND5e.Alignment, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * An enumeration of item attunement types
+   * @enum {number}
+   */
+  attunementTypes: {
+    NONE: 0;
+    REQUIRED: 1;
+    ATTUNED: 2;
+  };
+
+  /**
+   * An enumeration of item attunement states
+   * @type {{"0": string, "1": string, "2": string}}
+   */
+  attunements: Record<DND5e['attunementTypes'][keyof DND5e['attunementTypes']], string>;
+
+  /* -------------------------------------------- */
+  weaponProficiencies: Record<DND5e.WeaponProficiency, string>;
+  toolProficiencies: Record<DND5e.ToolProficiency, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * This Object defines the various lengths of time which can occur
+   * @type {Object}
+   */
+  timePeriods: Record<DND5e.TimePeriod, String>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * This describes the ways that an ability can be activated
+   * @type {Object}
+   */
+  abilityActivationTypes: Record<DND5e.AbilityActivationType, string>;
+
+  /* -------------------------------------------- */
+
+  abilityConsumptionTypes: Record<DND5e.ConsumeType, string>;
+
+  /* -------------------------------------------- */
+
+  // Creature Sizes
+  actorSizes: Record<DND5e.Size, string>;
+  tokenSizes: Record<DND5e.Size, number>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Classification types for item action types
+   * @type {Object}
+   */
+  itemActionTypes: Record<DND5e.ActionType, string>;
+
+  /* -------------------------------------------- */
+  itemCapacityTypes: {
+    items: string;
+    weight: string;
+  };
+
+  /* -------------------------------------------- */
+
+  /**
+   * Enumerate the lengths of time over which an item can have limited use ability
+   * @type {Object}
+   */
+  limitedUsePeriods: Record<DND5e.UsePeriod, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The set of equipment types for armor, clothing, and other objects which can ber worn by the character
+   * @type {Object}
+   */
+  equipmentTypes: Record<DND5e.ArmorType, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The set of Armor Proficiencies which a character may have
+   * @type {Object}
+   */
+  armorProficiencies: Record<DND5e.ArmorProficiencies, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Enumerate the valid consumable types which are recognized by the system
+   * @type {Object}
+   */
+  comsumableTypes: Record<DND5e.ConsumableType, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The valid currency denominations supported by the 5e system
+   * @type {Object}
+   */
+  currencies: Record<DND5e.Currency, string>;
+
+  /**
+   * Define the upwards-conversion rules for registered currency types
+   * @type {{string, object}}
+   */
+  currencyConversion: Record<DND5e.Currency, { into: DND5e.Currency; each: number }>;
+
+  /* -------------------------------------------- */
+
+  // Damage Types
+  damageTypes: Record<DND5e.DamageType, string>;
+
+  // Damage Resistance Types
+  damageResistanceTypes: Record<DND5e.DamageResistanceType, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The valid units of measure for movement distances in the game system.
+   * By default this uses the imperial units of feet and miles.
+   * @type {Object<string,string>}
+   */
+  movementTypes: Record<DND5e.MovementType, string>;
+
+  /**
+   * The valid units of measure for movement distances in the game system.
+   * By default this uses the imperial units of feet and miles.
+   * @type {Object<string,string>}
+   */
+  movementUnits: Record<DND5e.Unit, string>;
+
+  /**
+   * The valid units of measure for the range of an action or effect.
+   * This object automatically includes the movement units from DND5E.movementUnits
+   * @type {Object<string,string>}
+   */
+  distanceUnits: Record<DND5e.DistanceUnit, string> & DND5e['movementUnits'];
+
+  /* -------------------------------------------- */
+
+  /**
+   * Configure aspects of encumbrance calculation so that it could be configured by modules
+   * @type {Object}
+   */
+  encumbrance: {
+    currencyPerWeight: number;
+    strMultiplier: number;
+    vehicleWeightMultiplier: number;
+  };
+
+  /* -------------------------------------------- */
+
+  /**
+   * This Object defines the types of single or area targets which can be applied
+   * @type {Object}
+   */
+  targetTypes: Record<DND5e.TargetType, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Map the subset of target types which produce a template area of effect
+   * The keys are DND5E target types and the values are MeasuredTemplate shape types
+   * @type {Object}
+   */
+  areaTargetTypes: Record<DND5e.AreaTarget, string>;
+
+  /* -------------------------------------------- */
+
+  // Healing Types
+  healingTypes: {
+    healing: string;
+    temphp: string;
+  };
+
+  /* -------------------------------------------- */
+
+  /**
+   * Enumerate the denominations of hit dice which can apply to classes
+   * @type {Array.<string>}
+   */
+  hitDieTypes: `d${string}`[];
+
+  /* -------------------------------------------- */
+
+  /**
+   * The set of possible sensory perception types which an Actor may have
+   * @type {object}
+   */
+  senses: Record<DND5e.Senses, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The set of skill which can be trained
+   * @type {Object}
+   */
+  skills: Record<DND5e.SkillType, string>;
+
+  /* -------------------------------------------- */
+
+  spellPreparationModes: Record<DND5e.Preparation, string>;
+  spellUpcastModes: DND5e.Preparation[];
+  spellProgression: Record<DND5e.SpellcasterProgression, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The available choices for how spell damage scaling may be computed
+   * @type {Object}
+   */
+  spellScalingModes: Record<DND5e.SpellScaling, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Define the set of types which a weapon item can take
+   * @type {Object}
+   */
+  weaponTypes: Record<DND5e.WeaponType, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Define the set of weapon property flags which can exist on a weapon
+   * @type {Object}
+   */
+  weaponProperties: Record<DND5e.WeaponProperty, string>;
+
+  // Spell Components
+  spellComponents: Record<DND5e.SpellComponent, string>;
+
+  // Spell Schools
+  spellSchools: Record<DND5e.SpellSchool, string>;
+
+  // Spell Levels
+  spellLevels: Record<DND5e.SpellLevel, string>;
+
+  // Spell Scroll Compendium UUIDs
+  spellScrollIds: Record<DND5e.SpellLevel, string>;
+
+  /**
+   * Define the standard slot progression by character level.
+   * The entries of this array represent the spell slot progression for a full spell-caster.
+   * @type {Array[]}
+   */
+  SPELL_SLOT_TABLE: number[][];
+
+  /* -------------------------------------------- */
+
+  // Polymorph options.
+  polymorphSettings: Record<DND5e.PolymorphSetting, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Skill, ability, and tool proficiency levels
+   * Each level provides a proficiency multiplier
+   * @type {Object}
+   */
+  proficiencyLevels: Record<number, string>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The amount of cover provided by an object.
+   * In cases where multiple pieces of cover are
+   * in play, we take the highest value.
+   */
+  cover: Record<number, string>;
+
+  /* -------------------------------------------- */
+
+  // Condition Types
+  conditionTypes: Record<DND5e.ConditionType, string>;
+
+  // Languages
+  languages: Record<DND5e.Language, string>;
+
+  // Character Level XP Requirements
+  CHARACTER_EXP_LEVELS: number[];
+
+  // Challenge Rating XP Levels
+  CR_EXP_LEVELS: number[];
+
+  // Character Features Per Class And Level
+  classFeatures: ClassFeatures;
+
+  // Configure Optional Character Flags
+  characterFlags: Record<
+    DND5e.CharacterFlag,
+    {
+      name: string;
+      hint: string;
+      section: string;
+      type: Boolean;
+      placeholder?: boolean;
+    }
+  > & {
+    observantFeat: {
+      skills: DND5e.SkillType[];
+    };
+    reliableAthlete: {
+      abilities: DND5e.AbilityType[];
+    };
+  };
+
+  // Configure allowed status flags
+  allowedActorFlags: [...DND5e.CharacterFlagArr, 'isPolymorphed', 'originalActor'];
+}

--- a/dnd5e/module/config.d.ts
+++ b/dnd5e/module/config.d.ts
@@ -1,0 +1,4 @@
+import '@league-of-foundry-developers/foundry-vtt-types';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+declare interface DND5e {}

--- a/dnd5e/module/dice.d.ts
+++ b/dnd5e/module/dice.d.ts
@@ -1,8 +1,214 @@
-export declare function simplifyRollFormula(...args: any[]): any;
+import '@league-of-foundry-developers/foundry-vtt-types';
 
-declare function _isUnsupportedTerm(...args: any[]): any;
+import DND5e from '../dnd5e';
 
-export declare function d20Roll(...args: any[]): Promise<any>;
-export declare function _d20RollDialog(...args: any[]): Promise<any>;
-export declare function damageRoll(...args: any[]): Promise<any>;
-export declare function _damageRollDialog(...args: any[]): Promise<any>;
+/**
+ * A standardized helper function for simplifying the constant parts of a multipart roll formula
+ *
+ * @param {string} formula                 The original Roll formula
+ * @param {Object} data                    Actor or item data against which to parse the roll
+ * @param {Object} options                 Formatting options
+ * @param {boolean} options.constantFirst   Puts the constants before the dice terms in the resulting formula
+ *
+ * @return {string}                        The resulting simplified formula
+ */
+export declare function simplifyRollFormula(formula: string, data: Actor.Data | Item.Data): string;
+
+/**
+ * Only some terms are supported by simplifyRollFormula, this method returns true when the term is not supported.
+ * @param {*} term - A single Dice term to check support on
+ * @return {Boolean} True when unsupported, false if supported
+ */
+declare function _isUnsupportedTerm(term: any): boolean;
+
+/* -------------------------------------------- */
+
+/**
+ * A standardized helper function for managing core 5e "d20 rolls"
+ *
+ * Holding SHIFT, ALT, or CTRL when the attack is rolled will "fast-forward".
+ * This chooses the default options of a normal attack with no bonus, Advantage, or Disadvantage respectively
+ *
+ * @param {Array} parts             The dice roll component parts, excluding the initial d20
+ * @param {Object} data             Actor or item data against which to parse the roll
+ * @param {Event|object} event      The triggering event which initiated the roll
+ * @param {string} rollMode         A specific roll mode to apply as the default for the resulting roll
+ * @param {string|null} template    The HTML template used to render the roll dialog
+ * @param {string|null} title       The dice roll UI window title
+ * @param {Object} speaker          The ChatMessage speaker to pass when creating the chat
+ * @param {string|null} flavor      Flavor text to use in the posted chat message
+ * @param {Boolean} fastForward     Allow fast-forward advantage selection
+ * @param {Function} onClose        Callback for actions to take when the dialog form is closed
+ * @param {Object} dialogOptions    Modal dialog options
+ * @param {boolean} advantage       Apply advantage to the roll (unless otherwise specified)
+ * @param {boolean} disadvantage    Apply disadvantage to the roll (unless otherwise specified)
+ * @param {number} critical         The value of d20 result which represents a critical success
+ * @param {number} fumble           The value of d20 result which represents a critical failure
+ * @param {number} targetValue      Assign a target value against which the result of this roll should be compared
+ * @param {boolean} elvenAccuracy   Allow Elven Accuracy to modify this roll?
+ * @param {boolean} halflingLucky   Allow Halfling Luck to modify this roll?
+ * @param {boolean} reliableTalent  Allow Reliable Talent to modify this roll?
+ * @param {boolean} chatMessage     Automatically create a Chat Message for the result of this roll
+ * @param {object} messageData      Additional data which is applied to the created Chat Message, if any
+ *
+ * @return {Promise}                A Promise which resolves once the roll workflow has completed
+ */
+export declare function d20Roll<Data extends Actor.Data | Item.Data = Actor.Data | Item.Data>({
+  parts,
+  data,
+  event,
+  rollMode,
+  template,
+  title,
+  speaker,
+  flavor,
+  fastForward,
+  dialogOptions,
+  advantage,
+  disadvantage,
+  critical,
+  fumble,
+  targetValue,
+  elvenAccuracy,
+  halflingLucky,
+  reliableTalent,
+  chatMessage,
+  messageData
+}: {
+  parts?: string[];
+  data?: Data;
+  event?: Event | Record<string, unknown>;
+  rollMode?: DND5e.RollMode | null;
+  template?: string | null;
+  title?: string | null;
+  speaker?: ChatMessage.SpeakerData | null;
+  flavor?: string | null;
+  fastForward?: boolean | null;
+  dialogOptions: Partial<Dialog.Options>;
+  advantage?: boolean | null;
+  disadvantage?: boolean | null;
+  critical?: number;
+  fumble?: number;
+  targetValue?: number | null;
+  elvenAccuracy?: boolean;
+  halflingLucky?: boolean;
+  reliableTalent?: boolean;
+  chatMessage?: boolean;
+  messageData?: ChatMessage.MessageData;
+}): Promise<Roll<Data>>;
+
+/* -------------------------------------------- */
+
+/**
+ * Present a Dialog form which creates a d20 roll once submitted
+ * @return {Promise<Roll>}
+ * @private
+ */
+declare function _d20RollDialog({
+  template,
+  title,
+  parts,
+  allowCritical,
+  rollMode,
+  dialogOptions
+}: {
+  template: string;
+  title: string;
+  parts: string[];
+  allowCritical: boolean;
+  rollMode: DND5e.RollMode;
+  dialogOptions: Partial<Dialog.Options>;
+  roll: Roll;
+}): Promise<void>;
+
+/* -------------------------------------------- */
+
+/**
+ * A standardized helper function for managing core 5e "d20 rolls"
+ *
+ * Holding SHIFT, ALT, or CTRL when the attack is rolled will "fast-forward".
+ * This chooses the default options of a normal attack with no bonus, Critical, or no bonus respectively
+ *
+ * @param {Array} parts           The dice roll component parts, excluding the initial d20
+ * @param {Actor} actor           The Actor making the damage roll
+ * @param {Object} data           Actor or item data against which to parse the roll
+ * @param {Event|object}[event    The triggering event which initiated the roll
+ * @param {string} rollMode       A specific roll mode to apply as the default for the resulting roll
+ * @param {String} template       The HTML template used to render the roll dialog
+ * @param {String} title          The dice roll UI window title
+ * @param {Object} speaker        The ChatMessage speaker to pass when creating the chat
+ * @param {string} flavor         Flavor text to use in the posted chat message
+ * @param {boolean} allowCritical Allow the opportunity for a critical hit to be rolled
+ * @param {Boolean} critical      Flag this roll as a critical hit for the purposes of fast-forward rolls
+ * @param {number} criticalBonusDice    A number of bonus damage dice that are added for critical hits
+ * @param {number} criticalMultiplier   A critical hit multiplier which is applied to critical hits
+ * @param {Boolean} fastForward   Allow fast-forward advantage selection
+ * @param {Function} onClose      Callback for actions to take when the dialog form is closed
+ * @param {Object} dialogOptions  Modal dialog options
+ * @param {boolean} chatMessage     Automatically create a Chat Message for the result of this roll
+ * @param {object} messageData      Additional data which is applied to the created Chat Message, if any
+ *
+ * @return {Promise}              A Promise which resolves once the roll workflow has completed
+ */
+export declare function damageRoll<Data extends Actor.Data | Item.Data = Actor.Data | Item.Data>({
+  parts,
+  actor,
+  data,
+  event,
+  rollMode,
+  template,
+  title,
+  speaker,
+  flavor,
+  allowCritical,
+  critical,
+  criticalBonusDie,
+  criticalMuliplier,
+  fastForward,
+  dialogOptions,
+  chatMessage,
+  messageData
+}: {
+  parts: string[];
+  actor: Actor;
+  data: Data;
+  event?: Event | Record<string, unknown>;
+  rollMode?: DND5e.RollMode | null;
+  template: string;
+  title: string;
+  speaker: ChatMessage.SpeakerData;
+  flavor: string;
+  allowCritical?: boolean;
+  critical?: boolean;
+  criticalBonusDie?: number;
+  criticalMuliplier?: number;
+  fastForward?: boolean | null;
+  dialogOptions: Partial<Dialog.Options>;
+  chatMessage?: boolean;
+  messageData?: ChatMessage.MessageData;
+}): Promise<Roll<Data>>;
+
+/* -------------------------------------------- */
+
+/**
+ * Present a Dialog form which creates a damage roll once submitted
+ * @return {Promise<Roll>}
+ * @private
+ */
+export declare function _damageRollDialog<Data extends Actor.Data | Item.Data = Actor.Data | Item.Data>({
+  template,
+  title,
+  parts,
+  data,
+  allowCritical,
+  rollMode,
+  roll
+}: {
+  template: string;
+  title: string;
+  parts: string[];
+  data: Data;
+  allowCritical: boolean;
+  rollMode: DND5e.RollMode;
+  roll: (parts: string[], crit: boolean, form: HTMLFormElement) => Roll<Data>;
+}): Promise<Roll<Data> | null>;

--- a/dnd5e/module/dice.d.ts
+++ b/dnd5e/module/dice.d.ts
@@ -1,0 +1,8 @@
+export declare function simplifyRollFormula(...args: any[]): any;
+
+declare function _isUnsupportedTerm(...args: any[]): any;
+
+export declare function d20Roll(...args: any[]): Promise<any>;
+export declare function _d20RollDialog(...args: any[]): Promise<any>;
+export declare function damageRoll(...args: any[]): Promise<any>;
+export declare function _damageRollDialog(...args: any[]): Promise<any>;

--- a/dnd5e/module/item/entity.d.ts
+++ b/dnd5e/module/item/entity.d.ts
@@ -1,70 +1,401 @@
 import '@league-of-foundry-developers/foundry-vtt-types';
+
 import type DND5e from '../../dnd5e';
+import type Actor5e from '../actor/entity';
+import type { d20Roll, damageRoll } from '../dice';
+
+interface Labels {
+  spell: {
+    level: string;
+    school: string;
+    components: Record<DND5e.SpellComponent, string>;
+    materials: string;
+  };
+
+  feat: {
+    featType: string;
+  };
+
+  equipment: {
+    armor: string;
+  };
+
+  activation: {
+    target: string;
+    range: string;
+    duration: string;
+    recharge: string;
+  };
+
+  actionType: {
+    damage: string[];
+    damageTypes: string[];
+  };
+}
+
+type AnyLabel = Labels[keyof Labels];
 
 /**
  * Override and extend the basic :class:`Item` implementation
  */
 declare class Item5e extends Item<Item5e.Data> {
+  /* -------------------------------------------- */
+  /*  Item Properties                             */
+  /* -------------------------------------------- */
+
   /**
-   * Get the valid item consumption targets which exist on the actor
-   * @param item         Item data for the item being displayed
-   * @return {{string: string}}   An object of potential consumption targets
-   * @private
+   * Determine which ability score modifier is used by this item
+   * @type {string|null}
    */
-  _getItemConsumptionTargets(
-    item: Item5e.Data
-  ): {
-    [K: string]: string;
-  };
+  get abilityMod(): string | null;
 
   /* -------------------------------------------- */
 
   /**
-   * Get the text item status which is shown beneath the Item type in the top-right corner of the sheet
-   * @return {string}
-   * @private
+   * Does the Item implement an attack roll as part of its usage
+   * @type {boolean}
    */
-  _getItemStatus(item: Item5e.Data): string;
+  get hasAttack(): boolean;
 
   /* -------------------------------------------- */
 
   /**
-   * Get the Array of item properties which are used in the small sidebar of the description tab
-   * @return {Array}
-   * @private
+   * Does the Item implement a damage roll as part of its usage
+   * @type {boolean}
    */
-  _getItemProperties(item: Item5e.Data): string[];
+  get hasDamage(): boolean;
 
   /* -------------------------------------------- */
 
   /**
-   * Is this item a separate large object like a siege engine or vehicle
-   * component that is usually mounted on fixtures rather than equipped, and
-   * has its own AC and HP.
-   * @param item
-   * @returns {boolean}
-   * @private
+   * Does the Item implement a versatile damage roll as part of its usage
+   * @type {boolean}
    */
-  _isItemMountable(item: Item5e.Data): boolean;
+  get isVersatile(): boolean;
 
   /* -------------------------------------------- */
 
   /**
-   * Add or remove a damage part from the damage formula
-   * @param {Event} event     The original click event
-   * @return {Promise}
-   * @private
+   * Does the item provide an amount of healing instead of conventional damage?
+   * @return {boolean}
    */
-  _onDamageControl(event: MouseEvent): Promise<this>;
+  get isHealing(): boolean;
 
   /* -------------------------------------------- */
 
   /**
-   * Handle spawning the TraitSelector application which allows a checkbox of multiple trait options
-   * @param {Event} event   The click event which originated the selection
+   * Does the Item implement a saving throw as part of its usage
+   * @type {boolean}
+   */
+  get hasSave(): boolean;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item have a target
+   * @type {boolean}
+   */
+  get hasTarget(): boolean;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Does the Item have an area of effect target
+   * @type {boolean}
+   */
+  get hasAreaTarget(): boolean;
+
+  /* -------------------------------------------- */
+
+  /**
+   * A flag for whether this Item is limited in it's ability to be used by charges or by recharge.
+   * @type {boolean}
+   */
+  get hasLimitedUses(): boolean;
+
+  /* -------------------------------------------- */
+  /*	Data Preparation														*/
+  /* -------------------------------------------- */
+
+  /**
+   * Update the derived spell DC for an item that requires a saving throw
+   * @returns {number|null}
+   */
+  getSaveDC(): number | null;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Update a label to the Item detailing its total to hit bonus.
+   * Sources:
+   * - item entity's innate attack bonus
+   * - item's actor's proficiency bonus if applicable
+   * - item's actor's global bonuses to the given item type
+   * - item's ammunition if applicable
+   *
+   * @returns {Object} returns `rollData` and `parts` to be used in the item's Attack roll
+   */
+  getAttackToHit(): { rollData: any; parts: string[] };
+
+  /* -------------------------------------------- */
+
+  /**
+   * Roll the item to Chat, creating a chat card which contains follow up attack or damage roll options
+   * @param {boolean} [configureDialog]     Display a configuration dialog for the item roll, if applicable?
+   * @param {string} [rollMode]             The roll display mode with which to display (or not) the card
+   * @param {boolean} [createMessage]       Whether to automatically create a chat message (if true) or simply return
+   *                                        the prepared chat message data (if false).
+   * @return {Promise<ChatMessage|object|void>}
+   */
+  roll({
+    configureDialog,
+    rollMode,
+    createMessage
+  }: {
+    configureDialog?: boolean;
+    rollMode: DND5e.RollMode;
+    createMessage?: boolean;
+  }): Promise<ChatMessage | ChatMessage.Data | void>;
+
+  /* -------------------------------------------- */
+  /*  Chat Cards																	*/
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare an object of chat data used to display a card for the Item in the chat log
+   * @param {Object} htmlOptions    Options used by the TextEditor.enrichHTML function
+   * @return {Object}               An object of chat data to render
+   */
+  getChatData({
+    secrets,
+    entities,
+    links,
+    rolls,
+    rollData // TODO: _createInlineRoll
+  }?: {
+    secrets: boolean;
+    entities: boolean;
+    links: boolean;
+    rolls: boolean;
+    rollData: object;
+  }): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare chat card data for equipment type items
    * @private
    */
-  _onConfigureClassSkills(event: MouseEvent): void;
+  _equipmentChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare chat card data for weapon type items
+   * @private
+   */
+  _weaponChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare chat card data for consumable type items
+   * @private
+   */
+  _consumableChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare chat card data for tool type items
+   * @private
+   */
+  _toolChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare chat card data for tool type items
+   * @private
+   */
+  _lootChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Render a chat card for Spell type data
+   * @return {Object}
+   * @private
+   */
+  _spellChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare chat card data for items of the "Feat" type
+   * @private
+   */
+  _featChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+
+  /* -------------------------------------------- */
+  /*  Item Rolls - Attack, Damage, Saves, Checks  */
+  /* -------------------------------------------- */
+
+  /**
+   * Place an attack roll using an item (weapon, feat, spell, or equipment)
+   * Rely upon the d20Roll logic for the core implementation
+   *
+   * @param {object} options        Roll options which are configured and provided to the d20Roll function
+   * @return {Promise<Roll|null>}   A Promise which resolves to the created Roll instance
+   */
+  rollAttack: typeof d20Roll;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Place a damage roll using an item (weapon, feat, spell, or equipment)
+   * Rely upon the damageRoll logic for the core implementation.
+   * @param {MouseEvent} [event]    An event which triggered this roll, if any
+   * @param {boolean} [critical]    Should damage be rolled as a critical hit?
+   * @param {number} [spellLevel]   If the item is a spell, override the level for damage scaling
+   * @param {boolean} [versatile]   If the item is a weapon, roll damage using the versatile formula
+   * @param {object} [options]      Additional options passed to the damageRoll function
+   * @return {Promise<Roll>}        A Promise which resolves to the created Roll instance
+   */
+  rollDamage({
+    event,
+    critical,
+    versatile,
+    options
+  }?: {
+    event?: MouseEvent;
+    critical?: boolean;
+    versatile?: boolean;
+    options?: Parameters<typeof damageRoll>[0];
+  }): Promise<Roll>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Adjust a cantrip damage formula to scale it for higher level characters and monsters
+   * @private
+   */
+  _scaleCantripDamage(parts: string[], scale: string, level: number, rollData: Record<string, unknown>): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Adjust the spell damage formula to scale it for spell level up-casting
+   * @param {Array} parts         The original damage parts
+   * @param {number} baseLevel    The default spell level
+   * @param {number} spellLevel   The casted spell level
+   * @param {string} formula      The scaling formula
+   * @param {object} rollData     A data object that should be applied to the scaled damage roll
+   * @return {string[]}           The scaled roll parts
+   * @private
+   */
+  _scaleSpellDamage(
+    parts: string[],
+    baseLevel: number,
+    spellLevel: number,
+    formula: string,
+    rollData: Record<string, unknown>
+  ): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Scale an array of damage parts according to a provided scaling formula and scaling multiplier
+   * @param {string[]} parts    Initial roll parts
+   * @param {string} scaling    A scaling formula
+   * @param {number} times      A number of times to apply the scaling formula
+   * @param {object} rollData   A data object that should be applied to the scaled damage roll
+   * @return {string[]}         The scaled roll parts
+   * @private
+   */
+  _scaleDamage(parts: string[], scaling: string, times: number, rollData: Record<string, unknown>): string[];
+
+  /* -------------------------------------------- */
+
+  /**
+   * Place an attack roll using an item (weapon, feat, spell, or equipment)
+   * Rely upon the d20Roll logic for the core implementation
+   *
+   * @return {Promise<Roll>}   A Promise which resolves to the created Roll instance
+   */
+  rollFormula({ spellLevel }?: { spellLevel: DND5e.SpellLevel }): Promise<Roll>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Perform an ability recharge test for an item which uses the d6 recharge mechanic
+   * @return {Promise<Roll>}   A Promise which resolves to the created Roll instance
+   */
+  rollRecharge(): Promise<Roll>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Roll a Tool Check. Rely upon the d20Roll logic for the core implementation
+   * @prarm {Object} options   Roll configuration options provided to the d20Roll function
+   * @return {Promise<Roll>}   A Promise which resolves to the created Roll instance
+   */
+  rollToolCheck: typeof d20Roll;
+
+  /* -------------------------------------------- */
+
+  static chatListeners(html: JQuery): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle execution of a chat card action via a click event on one of the card buttons
+   * @param {Event} event       The originating click event
+   * @returns {Promise}         A promise which resolves once the handler workflow is complete
+   * @private
+   */
+  static _onChatCardAction(event: MouseEvent): Promise<void>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle toggling the visibility of chat card content when the name is clicked
+   * @param {Event} event   The originating click event
+   * @private
+   */
+  static _onChatCardToggleContent(event: MouseEvent): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the Actor which is the author of a chat card
+   * @param {HTMLElement} card    The chat card being used
+   * @return {Actor|null}         The Actor entity or null
+   * @private
+   */
+  static _getChatCardActor(card: HTMLElement): Actor5e | null;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the Actor which is the author of a chat card
+   * @param {HTMLElement} card    The chat card being used
+   * @return {Array.<Actor>}      An Array of Actor entities, if any
+   * @private
+   */
+  static _getChatCardTargets(card: HTMLElement): Actor5e[];
+
+  /* -------------------------------------------- */
+  /*  Factory Methods                             */
+  /* -------------------------------------------- */
+
+  /**
+   * Create a consumable spell scroll Item from a spell Item.
+   * @param {Item5e} spell      The spell to be made into a scroll
+   * @return {Item5e}           The created scroll consumable item
+   * @private
+   */
+  static createScrollFromSpell(spell: Item5e): Promise<Item5e>;
 }
 
 declare namespace Item5e {

--- a/dnd5e/module/item/entity.d.ts
+++ b/dnd5e/module/item/entity.d.ts
@@ -1,0 +1,302 @@
+import '@league-of-foundry-developers/foundry-vtt-types';
+import type DND5e from '../../dnd5e';
+
+/**
+ * Override and extend the basic :class:`Item` implementation
+ */
+declare class Item5e extends Item<Item5e.Data> {
+  /**
+   * Get the valid item consumption targets which exist on the actor
+   * @param item         Item data for the item being displayed
+   * @return {{string: string}}   An object of potential consumption targets
+   * @private
+   */
+  _getItemConsumptionTargets(
+    item: Item5e.Data
+  ): {
+    [K: string]: string;
+  };
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the text item status which is shown beneath the Item type in the top-right corner of the sheet
+   * @return {string}
+   * @private
+   */
+  _getItemStatus(item: Item5e.Data): string;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the Array of item properties which are used in the small sidebar of the description tab
+   * @return {Array}
+   * @private
+   */
+  _getItemProperties(item: Item5e.Data): string[];
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this item a separate large object like a siege engine or vehicle
+   * component that is usually mounted on fixtures rather than equipped, and
+   * has its own AC and HP.
+   * @param item
+   * @returns {boolean}
+   * @private
+   */
+  _isItemMountable(item: Item5e.Data): boolean;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add or remove a damage part from the damage formula
+   * @param {Event} event     The original click event
+   * @return {Promise}
+   * @private
+   */
+  _onDamageControl(event: MouseEvent): Promise<this>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle spawning the TraitSelector application which allows a checkbox of multiple trait options
+   * @param {Event} event   The click event which originated the selection
+   * @private
+   */
+  _onConfigureClassSkills(event: MouseEvent): void;
+}
+
+declare namespace Item5e {
+  export namespace Templates {
+    export interface ItemDescription {
+      description: {
+        value: string;
+        chat: string;
+        unidentified: string;
+      };
+      source: string;
+    }
+
+    export interface PhysicalItem {
+      quantity: number;
+      weight: number;
+      price: number;
+      attuned: boolean;
+      attunement: number;
+      equipped: boolean;
+      rarity: string;
+      identified: false;
+    }
+
+    export interface ActivatedEffect {
+      activation: {
+        type: DND5e.ActivationType;
+        cost: number;
+        condition: string;
+      };
+
+      duration: {
+        value: number | null;
+        units: DND5e.DurationType | null;
+      };
+
+      target: {
+        value: number | null;
+        width: number | null;
+        units: DND5e.TargetUnitType | '';
+        type: DND5e.TargetType | '';
+      };
+
+      range: {
+        value: number | null;
+        long: number | null;
+        units: DND5e.TargetUnitType | '';
+      };
+
+      uses: {
+        value: number;
+        max: number;
+        per: number | null;
+      };
+
+      consume: {
+        type: DND5e.ConsumeType;
+        target: DND5e.ConsumeTarget | null;
+        amount: number | null;
+      };
+    }
+
+    export interface Action {
+      ability: DND5e.AbilityType | null;
+      actionType: DND5e.ActionType | null;
+      attackBonus: number;
+      chatFlavor: string;
+      critical: boolean | null;
+      damage: {
+        parts: [string, DND5e.DamageType][];
+        versatile: string;
+      };
+      formula: string;
+      save: {
+        ability: DND5e.AbilityType;
+        dc: number | null;
+        scaling: string;
+      };
+    }
+
+    export interface Mountable {
+      armor: {
+        value: number;
+      };
+      hp: {
+        value: number;
+        max: number;
+        dt: number | null;
+        conditions: string;
+      };
+    }
+
+    export interface Weapon {
+      weaponType: string;
+      properties: {};
+      proficient: boolean;
+    }
+
+    export interface Equipment {
+      armor: {
+        type: DND5e.ArmorType;
+        value: number;
+        dex: number | null;
+      };
+
+      speed: {
+        value: number | null;
+        conditions: string;
+      };
+
+      strength: number;
+      stealth: boolean;
+      proficient: boolean;
+    }
+
+    export interface Consumable {
+      consumableType: string;
+      uses: {
+        autoDestroy: boolean;
+      };
+    }
+
+    export interface Tool {
+      ability: DND5e.Ability;
+      chatFlavor: string;
+      proficient: number;
+    }
+
+    export interface Class<Choices extends DND5e.Skills[] = DND5e.Skills[]> {
+      levels: number;
+      subclass: string;
+      hitDice: `d${number}`;
+      hitDiceUsed: number;
+      skills: {
+        number: number;
+        choices: Choices;
+
+        // value is a subset of choices
+        value: Choices;
+      };
+    }
+
+    export interface Spell {
+      level: DND5e.SpellLevel;
+      school: DND5e.School;
+      components: {
+        value: string;
+        vocal: boolean;
+        somatic: boolean;
+        material: boolean;
+        ritual: boolean;
+        concentration: boolean;
+      };
+
+      materials: {
+        value: string;
+        consumed: boolean;
+        cost: number;
+        supply: number;
+      };
+
+      preparation: {
+        mode: DND5e.Preparation;
+        prepared: boolean;
+      };
+
+      scaling: {
+        mode: string;
+        formula: string | null;
+      };
+    }
+
+    export interface Feat {
+      requirements: string;
+      recharge: {
+        value: number | string;
+        charged: boolean;
+      };
+    }
+
+    export interface Backpack {
+      capacity: {
+        type: string;
+        value: number;
+        weightless: boolean;
+      };
+      currency: Record<DND5e.Currencies, number>;
+    }
+  }
+
+  export interface Data extends Item.Data<Data.Data> {
+    data: Data.Data;
+    effects: ActiveEffect.Data[];
+    img: string;
+    name: string;
+    permission: Entity.Permission;
+    sort: number;
+    type: DND5e.ItemType;
+  }
+
+  export namespace Data {
+    export type Weapon = Templates.ItemDescription &
+      Templates.PhysicalItem &
+      Templates.ActivatedEffect &
+      Templates.Action &
+      Templates.Mountable &
+      Templates.Weapon;
+
+    export type Equipment = Templates.ItemDescription &
+      Templates.PhysicalItem &
+      Templates.ActivatedEffect &
+      Templates.Action &
+      Templates.Mountable &
+      Templates.Equipment;
+
+    export type Consumable = Templates.ItemDescription &
+      Templates.PhysicalItem &
+      Templates.ActivatedEffect &
+      Templates.Action &
+      Templates.Consumable;
+
+    export type Tool = Templates.ItemDescription & Templates.PhysicalItem & Templates.Tool;
+    export type Loot = Templates.ItemDescription & Templates.PhysicalItem;
+    export type Class<Choices extends DND5e.Skills[] = DND5e.Skills[]> = Templates.ItemDescription &
+      Templates.Class<Choices>;
+
+    export type Spell = Templates.ItemDescription & Templates.ActivatedEffect & Templates.Action & Templates.Spell;
+    export type Feat = Templates.ItemDescription & Templates.ActivatedEffect & Templates.Action & Templates.Feat;
+    export type Backpack = Templates.ItemDescription & Templates.PhysicalItem & Templates.Backpack;
+
+    export type Data = Weapon | Equipment | Consumable | Tool | Loot | Class | Spell | Feat | Backpack;
+  }
+}
+
+export default Item5e;

--- a/dnd5e/module/item/entity.d.ts
+++ b/dnd5e/module/item/entity.d.ts
@@ -134,7 +134,7 @@ declare namespace Item5e {
       chatFlavor: string;
       critical: boolean | null;
       damage: {
-        parts: [string, DND5e.DamageType][];
+        parts: [string, DND5e.DamageType | 'none'][];
         versatile: string;
       };
       formula: string;
@@ -193,7 +193,7 @@ declare namespace Item5e {
       proficient: number;
     }
 
-    export interface Class<Choices extends DND5e.Skills[] = DND5e.Skills[]> {
+    export interface Class<Choices extends DND5e.SkillType[] = DND5e.SkillType[]> {
       levels: number;
       subclass: string;
       hitDice: `d${number}`;
@@ -209,7 +209,7 @@ declare namespace Item5e {
 
     export interface Spell {
       level: DND5e.SpellLevel;
-      school: DND5e.School;
+      school: DND5e.SpellSchool;
       components: {
         value: string;
         vocal: boolean;
@@ -251,7 +251,7 @@ declare namespace Item5e {
         value: number;
         weightless: boolean;
       };
-      currency: Record<DND5e.Currencies, number>;
+      currency: Record<DND5e.Currency, number>;
     }
   }
 
@@ -288,7 +288,7 @@ declare namespace Item5e {
 
     export type Tool = Templates.ItemDescription & Templates.PhysicalItem & Templates.Tool;
     export type Loot = Templates.ItemDescription & Templates.PhysicalItem;
-    export type Class<Choices extends DND5e.Skills[] = DND5e.Skills[]> = Templates.ItemDescription &
+    export type Class<Choices extends DND5e.SkillType[] = DND5e.SkillType[]> = Templates.ItemDescription &
       Templates.Class<Choices>;
 
     export type Spell = Templates.ItemDescription & Templates.ActivatedEffect & Templates.Action & Templates.Spell;

--- a/dnd5e/module/item/sheet.d.ts
+++ b/dnd5e/module/item/sheet.d.ts
@@ -1,3 +1,70 @@
-declare class ItemSheet5e {}
+import Item5e from './entity';
+
+/**
+ * Override and extend the core ItemSheet implementation to handle specific item types
+ * @extends {ItemSheet}
+ */
+declare class ItemSheet5e extends ItemSheet {
+  /**
+   * Get the valid item consumption targets which exist on the actor
+   * @param item         Item data for the item being displayed
+   * @return {{string: string}}   An object of potential consumption targets
+   * @private
+   */
+  _getItemConsumptionTargets(
+    item: Item5e.Data
+  ): {
+    [K: string]: string;
+  };
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the text item status which is shown beneath the Item type in the top-right corner of the sheet
+   * @return {string}
+   * @private
+   */
+  _getItemStatus(item: Item5e.Data): string;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the Array of item properties which are used in the small sidebar of the description tab
+   * @return {Array}
+   * @private
+   */
+  _getItemProperties(item: Item5e.Data): string[];
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this item a separate large object like a siege engine or vehicle
+   * component that is usually mounted on fixtures rather than equipped, and
+   * has its own AC and HP.
+   * @param item
+   * @returns {boolean}
+   * @private
+   */
+  _isItemMountable(item: Item5e.Data): boolean;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add or remove a damage part from the damage formula
+   * @param {Event} event     The original click event
+   * @return {Promise}
+   * @private
+   */
+  _onDamageControl(event: MouseEvent): Promise<this>;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle spawning the TraitSelector application which allows a checkbox of multiple trait options
+   * @param {Event} event   The click event which originated the selection
+   * @private
+   */
+  _onConfigureClassSkills(event: MouseEvent): void;
+}
 
 export default ItemSheet5e;

--- a/dnd5e/module/item/sheet.d.ts
+++ b/dnd5e/module/item/sheet.d.ts
@@ -1,0 +1,3 @@
+declare class ItemSheet5e {}
+
+export default ItemSheet5e;

--- a/dnd5e/module/macros.d.ts
+++ b/dnd5e/module/macros.d.ts
@@ -1,0 +1,2 @@
+export declare function create5eMacro(...args: any[]): Promise<any>;
+export declare function rollItemMacro(...args: any[]): any;

--- a/dnd5e/module/macros.d.ts
+++ b/dnd5e/module/macros.d.ts
@@ -1,2 +1,22 @@
-export declare function create5eMacro(...args: any[]): Promise<any>;
-export declare function rollItemMacro(...args: any[]): any;
+/* -------------------------------------------- */
+/*  Hotbar Macros                               */
+/* -------------------------------------------- */
+
+/**
+ * Create a Macro from an Item drop.
+ * Get an existing item macro if one exists, otherwise create a new one.
+ * @param {Object} data     The dropped data
+ * @param {number} slot     The hotbar slot to use
+ * @returns {Promise}
+ */
+export declare function create5eMacro(data: Item.Data | Actor.Data, slot: number): Promise<boolean | undefined>;
+
+/* -------------------------------------------- */
+
+/**
+ * Create a Macro from an Item drop.
+ * Get an existing item macro if one exists, otherwise create a new one.
+ * @param {string} itemName
+ * @return {Promise}
+ */
+export declare function rollItemMacro(itemName: string): Roll;

--- a/dnd5e/module/migration.d.ts
+++ b/dnd5e/module/migration.d.ts
@@ -1,11 +1,115 @@
-export declare function migrateWorld(...args: any[]): Promise<any>;
-export declare function migrateCompendium(...args: any[]): Promise<any>;
-export declare function migrateActorData(...args: any[]): Promise<any>;
-export declare function cleanActorData(...args: any[]): any;
-export declare function migrateItemData(...args: any[]): any;
-export declare function migrateSceneData(...args: any[]): any;
-export declare function _migrateActorMovement(...args: any[]): any;
-export declare function _migrateActorSenses(...args: any[]): any;
+import '@league-of-foundry-developers/foundry-vtt-types';
+
+import Actor5e from './actor/entity';
+import Item5e from './item/entity';
+
+/**
+ * Perform a system migration for the entire World, applying migrations for Actors, Items, and Compendium packs
+ * @return {Promise}      A Promise which resolves once the migration is completed
+ */
+export declare function migrateWorld(): Promise<void>;
+
+/* -------------------------------------------- */
+
+/**
+ * Apply migration rules to all Entities within a single Compendium pack
+ * @param pack
+ * @return {Promise}
+ */
+export declare function migrateCompendium(pack: Compendium): Promise<void>;
+
+/* -------------------------------------------- */
+/*  Entity Type Migration Helpers               */
+/* -------------------------------------------- */
+
+/**
+ * Migrate a single Actor entity to incorporate latest data model changes
+ * Return an Object of updateData to be applied
+ * @param {object} actor    The actor data object to update
+ * @return {Object}         The updateData to apply
+ */
+export declare function migrateActorData(actor: Actor5e): Promise<Record<string, unknown>>;
+
+/* -------------------------------------------- */
+
+/**
+ * Scrub an Actor's system data, removing all keys which are not explicitly defined in the system template
+ * @param {Object} actorData    The data object for an Actor
+ * @return {Object}             The scrubbed Actor data
+ */
+export declare function cleanActorData(actor: Actor5e.Data): Actor5e.Data;
+
+/* -------------------------------------------- */
+
+/**
+ * Migrate a single Item entity to incorporate latest data model changes
+ * @param item
+ */
+export declare function migrateItemData(item: Item5e): Record<string, unknown>;
+
+/* -------------------------------------------- */
+
+/**
+ * Migrate a single Scene entity to incorporate changes to the data model of it's actor data overrides
+ * Return an Object of updateData to be applied
+ * @param {Object} scene  The Scene data to Update
+ * @return {Object}       The updateData to apply
+ */
+export declare function migrateSceneData(scene: Scene.Data): Record<string, unknown>;
+
+/* -------------------------------------------- */
+/*  Low level migration utilities
+/* -------------------------------------------- */
+
+/**
+ * Migrate the actor speed string to movement object
+ * @private
+ */
+export declare function _migrateActorMovement<UpdateData extends Record<string, unknown> = Record<string, unknown>>(
+  actorData: Actor.Data,
+  updateData: UpdateData
+): UpdateData & Record<string, unknown>;
+
+/* -------------------------------------------- */
+
+/**
+ * Migrate the actor traits.senses string to attributes.senses object
+ * @private
+ */
+export declare function _migrateActorSenses<UpdateData extends Record<string, unknown> = Record<string, unknown>>(
+  actor: Actor5e.Data
+): UpdateData & Record<string, unknown>;
+
+/* -------------------------------------------- */
+
+/**
+ * Delete the old data.attuned boolean
+ * @private
+ */
 export declare function _migrateItemAttunement(...args: any[]): any;
-export declare function purgeFlags(...args: any[]): Promise<any>;
-export declare function removeDeprecatedObjects(...args: any[]): any;
+
+/* -------------------------------------------- */
+
+/**
+ * A general tool to purge flags from all entities in a Compendium pack.
+ * @param {Compendium} pack   The compendium pack to clean
+ * @private
+ */
+export declare function purgeFlags(pack: Compendium): Promise<void>;
+
+/* -------------------------------------------- */
+
+declare type FilterDeprecated<Obj> = Pick<
+  Obj,
+  {
+    [K in keyof Obj]: Obj[K] extends { _deprecated: true } ? never : K;
+  }[keyof Obj]
+>;
+
+/**
+ * Purge the data model of any inner objects which have been flagged as _deprecated.
+ * @param {object} data   The data to clean
+ * @private
+ */
+
+export declare function removeDeprecatedObjects<Obj>(data: Obj): FilterDeprecated<Obj>;

--- a/dnd5e/module/migration.d.ts
+++ b/dnd5e/module/migration.d.ts
@@ -1,0 +1,11 @@
+export declare function migrateWorld(...args: any[]): Promise<any>;
+export declare function migrateCompendium(...args: any[]): Promise<any>;
+export declare function migrateActorData(...args: any[]): Promise<any>;
+export declare function cleanActorData(...args: any[]): any;
+export declare function migrateItemData(...args: any[]): any;
+export declare function migrateSceneData(...args: any[]): any;
+export declare function _migrateActorMovement(...args: any[]): any;
+export declare function _migrateActorSenses(...args: any[]): any;
+export declare function _migrateItemAttunement(...args: any[]): any;
+export declare function purgeFlags(...args: any[]): Promise<any>;
+export declare function removeDeprecatedObjects(...args: any[]): any;

--- a/dnd5e/module/pixi/ability-template.d.ts
+++ b/dnd5e/module/pixi/ability-template.d.ts
@@ -1,3 +1,31 @@
-declare class AbilityTemplate {}
+import Item5e from '../item/entity';
+
+/**
+ * A helper class for building MeasuredTemplates for 5e spells and abilities
+ * @extends {MeasuredTemplate}
+ */
+declare class AbilityTemplate {
+  /**
+   * A factory method to create an AbilityTemplate instance using provided data from an Item5e instance
+   * @param {Item5e} item               The Item object for which to construct the template
+   * @return {AbilityTemplate|null}     The template object, or null if the item does not produce a template
+   */
+  static fromItem(item: Item5e): AbilityTemplate | null;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Creates a preview of the spell template
+   */
+  drawPreview(): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Activate listeners for the template preview
+   * @param {CanvasLayer} initialLayer  The initially active CanvasLayer to re-activate after the workflow is complete
+   */
+  activatePreviewListeners(initialLayer: CanvasLayer): void;
+}
 
 export default AbilityTemplate;

--- a/dnd5e/module/pixi/ability-template.d.ts
+++ b/dnd5e/module/pixi/ability-template.d.ts
@@ -1,5 +1,3 @@
-import '@league-of-foundry-developers/foundry-vtt-types';
-
 declare class AbilityTemplate {}
 
 export default AbilityTemplate;

--- a/dnd5e/module/pixi/ability-template.d.ts
+++ b/dnd5e/module/pixi/ability-template.d.ts
@@ -1,0 +1,5 @@
+import '@league-of-foundry-developers/foundry-vtt-types';
+
+declare class AbilityTemplate {}
+
+export default AbilityTemplate;

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,6 @@ import './dnd5e/apps/short-rest';
 import './dnd5e/apps/trait-selector';
 
 import './dnd5e/item/entity';
-import './dnd5e/item/sheet';
+import './dnd5e/item/sheets';
 
 import './dnd5e/pixi/ability-template';

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import './dnd5e/dnd5e';
 
 import './dnd5e/module/canvas';
 import './dnd5e/module/chat';
-import './dnd5e/module/classFeature';
+import './dnd5e/module/classFeatures';
 import './dnd5e/module/combat';
 import './dnd5e/module/config';
 import './dnd5e/module/dice';


### PR DESCRIPTION
This repo has the goal of setting up a baseline for the repo as a whole.

- Adapts [Misterpott's types](https://github.com/misterpotts/fabricate/blob/refactor/types-maintainability/typings/dnd5e.d.ts).
- Creates a structure matching the [Foundry dnd5e repo](https://gitlab.com/foundrynet/dnd5e/).
- Types the entrypoint dnd5e.js which effects the CONFIG and a handful of other things. Stubs are in place for some types referenced although that may be fixed.
- Types Item5e and Actor5e's methods and templates.

Currently, I've disabled the `eslint-plugin-tsdoc` because I opted to copy the comments for methods verbatim from the source. Before merging we should decide whether to alter the config of the plugin, remove it entirely, or keep it and adapt the comments. I'm personally leaning towards the the first (or swap it) because it doesn't have support for `@private` but I've abstained from actually typing functions as private for accessibility. Although perhaps it should be typed as private as a `@ts-ignore` will fix that.