### PR TITLE
refactor: Item5e narrowing based on `type`

### DIFF
--- a/dnd5e/dnd5e.d.ts
+++ b/dnd5e/dnd5e.d.ts
@@ -124,18 +124,6 @@ declare namespace DND5e {
   type AreaTarget = 'cone' | 'cube' | 'cylinder' | 'line' | 'radius' | 'sphere' | 'square' | 'wall';
   type TargetType = AreaTarget | 'ally' | 'creature' | 'enemy' | 'none' | 'object' | 'self' | 'space';
 
-  type DurationType =
-    | 'days'
-    | 'hours'
-    | 'instantaneous'
-    | 'minutes'
-    | 'months'
-    | 'permanent'
-    | 'rounds'
-    | 'special'
-    | 'turns'
-    | 'years';
-
   type WeaponType = 'simpleM' | 'martialM' | 'simpleR' | 'martialR' | 'natural' | 'improv' | 'siege';
 
   interface Skill {
@@ -200,7 +188,7 @@ declare namespace DND5e {
   type SpellSchool = 'abj' | 'con' | 'div' | 'enc' | 'evo' | 'ill' | 'nec' | 'trs';
   type Preparation = 'prepared' | 'pact' | 'always' | 'atwill' | 'innate';
 
-  type SpellLevel = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+  type SpellLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
   type SpellType = `spell${SpellLevel}` | 'pact';
 
   type Resources = 'primary' | 'secondary' | 'tertiary';
@@ -434,11 +422,4 @@ declare namespace DND5e {
   type Class = keyof Subclasses;
 
   type RollMode = 'roll' | 'gmroll' | 'blindroll' | 'selfroll';
-}
-
-interface DND5E {
-  config: {
-    abilityAbbreviations: any;
-    abilityActivationTypes: any;
-  };
 }

--- a/dnd5e/module/actor/entity.d.ts
+++ b/dnd5e/module/actor/entity.d.ts
@@ -116,7 +116,7 @@ declare class Actor5e extends Actor<Actor5e.Data, Item5e> {
    * @param itemData - The item data to use
    * @param options - Options which
    */
-  private _preCreateOwnedItem(itemData: Item5e.Data, options: any): void;
+  private _preCreateOwnedItem(itemData: Item5e['data'], options: any): void;
 
   /* -------------------------------------------- */
   /*  Gameplay Mechanics                          */
@@ -331,7 +331,7 @@ declare namespace Actor5e {
     newDay: boolean;
   };
 
-  interface Data extends Actor.Data<Data.Data, Item5e.Data> {
+  interface Data extends Actor.Data<Data.Data, Item5e['data']> {
     folder: string;
     img: string;
     name: string;

--- a/dnd5e/module/item/entity.d.ts
+++ b/dnd5e/module/item/entity.d.ts
@@ -1,38 +1,19 @@
-interface Labels {
-  spell: {
-    level: string;
-    school: string;
-    components: Record<DND5e.SpellComponent, string>;
-    materials: string;
-  };
-
-  feat: {
-    featType: string;
-  };
-
-  equipment: {
-    armor: string;
-  };
-
-  activation: {
-    target: string;
-    range: string;
-    duration: string;
-    recharge: string;
-  };
-
-  actionType: {
-    damage: string[];
-    damageTypes: string[];
-  };
-}
-
-type AnyLabel = Labels[keyof Labels];
+type Items5e = {
+  weapon: Item.Data<Item5e.Data.Weapon> & { type: 'weapon' };
+  equipment: Item.Data<Item5e.Data.Equipment> & { type: 'equipment' };
+  consumable: Item.Data<Item5e.Data.Consumable> & { type: 'consumable' };
+  tool: Item.Data<Item5e.Data.Tool> & { type: 'tool' };
+  loot: Item.Data<Item5e.Data.Loot> & { type: 'loot' };
+  class: Item.Data<Item5e.Data.Class> & { type: 'class' };
+  spell: Item.Data<Item5e.Data.Spell> & { type: 'spell' };
+  feat: Item.Data<Item5e.Data.Feat> & { type: 'feat' };
+  backpack: Item.Data<Item5e.Data.Backpack> & { type: 'backpack' };
+};
 
 /**
  * Override and extend the basic :class:`Item` implementation
  */
-declare class Item5e extends Item<Item5e.Data> {
+declare class Item5e<Item5eData extends Item.Data = Items5e[keyof Items5e]> extends Item<Item5eData> {
   /* -------------------------------------------- */
   /*  Item Properties                             */
   /* -------------------------------------------- */
@@ -169,35 +150,35 @@ declare class Item5e extends Item<Item5e.Data> {
   /**
    * Prepare chat card data for equipment type items
    */
-  private _equipmentChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+  private _equipmentChatData(data: Item5e.Data.Equipment, labels: Item5e.Labels.Equipment, props: Array<any>): void;
 
   /* -------------------------------------------- */
 
   /**
    * Prepare chat card data for weapon type items
    */
-  private _weaponChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+  private _weaponChatData(data: Item5e.Data.Weapon, labels: Item5e.Labels.Weapon, props: Array<any>): void;
 
   /* -------------------------------------------- */
 
   /**
    * Prepare chat card data for consumable type items
    */
-  private _consumableChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+  private _consumableChatData(data: Item5e.Data.Consumable, labels: Item5e.Labels.Consumable, props: Array<any>): void;
 
   /* -------------------------------------------- */
 
   /**
    * Prepare chat card data for tool type items
    */
-  private _toolChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+  private _toolChatData(data: Item5e.Data.Tool, labels: Item5e.Labels.Tool, props: Array<any>): void;
 
   /* -------------------------------------------- */
 
   /**
    * Prepare chat card data for tool type items
    */
-  private _lootChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+  private _lootChatData(data: Item5e.Data.Loot, labels: Item5e.Labels.Loot, props: Array<any>): void;
 
   /* -------------------------------------------- */
 
@@ -205,14 +186,14 @@ declare class Item5e extends Item<Item5e.Data> {
    * Render a chat card for Spell type data
    * @returns the chat card for spells
    */
-  private _spellChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): any;
+  private _spellChatData(data: Item5e.Data.Spell, labels: Item5e.Labels.Spell, props: Array<any>): any;
 
   /* -------------------------------------------- */
 
   /**
    * Prepare chat card data for items of the "Feat" type
    */
-  private _featChatData(data: Item5e.Data.Data, labels: AnyLabel, props: Array<any>): void;
+  private _featChatData(data: Item5e.Data.Feat, labels: Item5e.Labels.Feat, props: Array<any>): void;
 
   /* -------------------------------------------- */
   /*  Item Rolls - Attack, Damage, Saves, Checks  */
@@ -398,7 +379,7 @@ declare namespace Item5e {
 
       duration: {
         value: number | null;
-        units: DND5e.DurationType | null;
+        units: DND5e.TimePeriod | null;
       };
 
       target: {
@@ -555,14 +536,59 @@ declare namespace Item5e {
     }
   }
 
-  interface Data extends Item.Data<Data.Data> {
-    data: Data.Data;
-    effects: ActiveEffect.Data[];
-    img: string;
-    name: string;
-    permission: Entity.Permission;
-    sort: number;
-    type: DND5e.ItemType;
+  namespace Labels {
+    // hasOwnProperty('activation')
+    interface Activation {
+      activation: string;
+      target: string;
+      range: string;
+      duration: string;
+      recharge: string;
+    }
+
+    interface Save {
+      save?: string;
+    }
+
+    interface Attack {
+      toHit?: string;
+    }
+
+    // hasOwnProperty('actionType')
+    interface Damage {
+      damage: string[];
+      damageTypes: string[];
+    }
+
+    type Spell = Activation &
+      Damage &
+      Save &
+      Attack & {
+        level: string;
+        school: string;
+        components: Record<DND5e.SpellComponent, string>;
+        materials: string;
+      };
+
+    type Feat = Activation &
+      Damage &
+      Save &
+      Attack & {
+        featType: string;
+      };
+
+    type Equipment = Activation &
+      Damage &
+      Attack &
+      Save & {
+        armor: string;
+      };
+
+    type Weapon = Activation & Damage & Attack & Save;
+
+    type Consumable = Activation & Damage & Attack & Save;
+    type Tool = {};
+    type Loot = {};
   }
 
   namespace Data {
@@ -594,7 +620,5 @@ declare namespace Item5e {
     type Spell = Templates.ItemDescription & Templates.ActivatedEffect & Templates.Action & Templates.Spell;
     type Feat = Templates.ItemDescription & Templates.ActivatedEffect & Templates.Action & Templates.Feat;
     type Backpack = Templates.ItemDescription & Templates.PhysicalItem & Templates.Backpack;
-
-    type Data = Weapon | Equipment | Consumable | Tool | Loot | Class | Spell | Feat | Backpack;
   }
 }

--- a/dnd5e/module/item/sheet.d.ts
+++ b/dnd5e/module/item/sheet.d.ts
@@ -8,7 +8,7 @@ declare class ItemSheet5e extends ItemSheet {
    * @returns An object of potential consumption targets
    */
   private _getItemConsumptionTargets(
-    item: Item5e.Data
+    item: Item5e['data']
   ): {
     [K: string]: string;
   };
@@ -19,7 +19,7 @@ declare class ItemSheet5e extends ItemSheet {
    * Get the text item status which is shown beneath the Item type in the top-right corner of the sheet
    * @returns The item's status
    */
-  private _getItemStatus(item: Item5e.Data): string;
+  private _getItemStatus(item: Item5e['data']): string;
 
   /* -------------------------------------------- */
 
@@ -27,7 +27,7 @@ declare class ItemSheet5e extends ItemSheet {
    * Get the Array of item properties which are used in the small sidebar of the description tab
    * @returns The item properties
    */
-  private _getItemProperties(item: Item5e.Data): string[];
+  private _getItemProperties(item: Item5e['data']): string[];
 
   /* -------------------------------------------- */
 
@@ -38,7 +38,7 @@ declare class ItemSheet5e extends ItemSheet {
    * @param item - The item data
    * @returns Whether the item is mountable
    */
-  private _isItemMountable(item: Item5e.Data): boolean;
+  private _isItemMountable(item: Item5e['data']): boolean;
 
   /* -------------------------------------------- */
 


### PR DESCRIPTION
Resolves #10

A few minor fixes for the dnd5e.d.ts file, as well as the first step on Item5e narrowing.

This is as far as we got with Item5e last night such that it works as expected when you use inline type gaurds in the absense of other narrowing logic.

```ts
        const activationType = getActivationType(
          'activation' in item.data.data ? item.data.data?.activation?.type : undefined
        );
```