### PR TITLE
fix(Actor abilities): Add missing properties

### DIFF
--- a/dnd5e/module/actor/entity.d.ts
+++ b/dnd5e/module/actor/entity.d.ts
@@ -351,6 +351,12 @@ declare namespace Actor5e {
         {
           value: number;
           proficient: number;
+          mod: number;
+          saveBonus: number;
+          checkBonus: number;
+          save: number | typeof NaN;
+          prof: number | typeof NaN;
+          dc: number | typeof NaN;
         }
       >;
       attributes: {

--- a/dnd5e/module/actor/entity.d.ts
+++ b/dnd5e/module/actor/entity.d.ts
@@ -429,6 +429,7 @@ declare namespace Actor5e {
           abilities: DND5e.AbilityBonus;
           spell: DND5e.SaveBonus;
         };
+        prof: number;
       };
     }
 


### PR DESCRIPTION
- Include mod, saveBonus, checkBonus, save, prof and dc in actor ability data
- Treat save prof and dc as being able to take the type NaN in common, as they seem to exist in Vehicles and are not 'undefined'. This may not be the optimal representation, but seems accurate

Addresses: #20